### PR TITLE
[Sparse Strip]: Text API (outlines only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,6 +3048,7 @@ version = "0.4.0"
 dependencies = [
  "image",
  "oxipng",
+ "skrifa",
  "vello_common",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,6 +3020,7 @@ name = "vello_api"
 version = "0.4.0"
 dependencies = [
  "peniko",
+ "skrifa",
 ]
 
 [[package]]
@@ -3038,6 +3039,7 @@ name = "vello_common"
 version = "0.4.0"
 dependencies = [
  "roxmltree",
+ "skrifa",
  "vello_api",
 ]
 
@@ -3069,6 +3071,7 @@ dependencies = [
  "png",
  "pollster",
  "roxmltree",
+ "skrifa",
  "vello_common",
  "wgpu",
  "winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,7 +3020,6 @@ name = "vello_api"
 version = "0.4.0"
 dependencies = [
  "peniko",
- "skrifa",
 ]
 
 [[package]]

--- a/sparse_strips/vello_api/Cargo.toml
+++ b/sparse_strips/vello_api/Cargo.toml
@@ -13,7 +13,6 @@ publish = false
 
 [dependencies]
 peniko = { workspace = true }
-skrifa = { workspace = true }
 
 [features]
 default = ["std"]

--- a/sparse_strips/vello_api/Cargo.toml
+++ b/sparse_strips/vello_api/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 
 [dependencies]
 peniko = { workspace = true }
+skrifa = { workspace = true }
 
 [features]
 default = ["std"]

--- a/sparse_strips/vello_api/src/glyph.rs
+++ b/sparse_strips/vello_api/src/glyph.rs
@@ -3,10 +3,6 @@
 
 //! Types for glyphs.
 
-use peniko::Font;
-use peniko::kurbo::Affine;
-use skrifa::instance::NormalizedCoord;
-
 /// Positioned glyph.
 #[derive(Copy, Clone, Default, Debug)]
 pub struct Glyph {
@@ -19,21 +15,4 @@ pub struct Glyph {
     pub x: f32,
     /// Y-offset in run, relative to transform.
     pub y: f32,
-}
-
-/// A sequence of glyphs with shared rendering properties.
-#[derive(Clone, Debug)]
-pub struct GlyphRun {
-    /// Glyphs in the run.
-    pub glyphs: Vec<Glyph>,
-    /// Font for all glyphs in the run.
-    pub font: Font,
-    /// Size of the font in pixels per em.
-    pub font_size: f32,
-    /// Global run transform.
-    pub transform: Affine,
-    /// Normalized variation coordinates for variable fonts.
-    pub normalized_coords: Vec<NormalizedCoord>,
-    /// Controls whether font hinting is enabled.
-    pub hint: bool,
 }

--- a/sparse_strips/vello_api/src/glyph.rs
+++ b/sparse_strips/vello_api/src/glyph.rs
@@ -1,0 +1,39 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Types for glyphs.
+
+use peniko::Font;
+use peniko::kurbo::Affine;
+use skrifa::instance::NormalizedCoord;
+
+/// Positioned glyph.
+#[derive(Copy, Clone, Default, Debug)]
+pub struct Glyph {
+    /// The font-specific identifier for this glyph.
+    ///
+    /// This ID is specific to the font being used and corresponds to the
+    /// glyph index within that font. It is *not* a Unicode code point.
+    pub id: u32,
+    /// X-offset in run, relative to transform.
+    pub x: f32,
+    /// Y-offset in run, relative to transform.
+    pub y: f32,
+}
+
+/// A sequence of glyphs with shared rendering properties.
+#[derive(Clone, Debug)]
+pub struct GlyphRun {
+    /// Glyphs in the run.
+    pub glyphs: Vec<Glyph>,
+    /// Font for all glyphs in the run.
+    pub font: Font,
+    /// Size of the font in pixels per em.
+    pub font_size: f32,
+    /// Global run transform.
+    pub transform: Affine,
+    /// Normalized variation coordinates for variable fonts.
+    pub normalized_coords: Vec<NormalizedCoord>,
+    /// Controls whether font hinting is enabled.
+    pub hint: bool,
+}

--- a/sparse_strips/vello_api/src/lib.rs
+++ b/sparse_strips/vello_api/src/lib.rs
@@ -12,4 +12,5 @@ pub use peniko;
 pub use peniko::color;
 pub use peniko::kurbo;
 pub mod execute;
+pub mod glyph;
 pub mod paint;

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 vello_api = { workspace = true, default-features = true }
 # for pico_svg
 roxmltree = "0.20.0"
+skrifa = { workspace = true }
 
 [features]
 simd = ["vello_api/simd"]

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -78,6 +78,7 @@ impl OutlinePen for OutlinePath {
     }
 }
 
+// TODO: Make this configurable.
 const HINTING_OPTIONS: HintingOptions = HintingOptions {
     engine: skrifa::outline::Engine::AutoFallback,
     target: skrifa::outline::Target::Smooth {

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -3,7 +3,8 @@
 
 //! Processing and drawing glyphs.
 
-use skrifa::instance::Size;
+use crate::peniko::Font;
+use skrifa::instance::{NormalizedCoord, Size};
 use skrifa::outline::DrawSettings;
 use skrifa::{
     GlyphId, MetadataProvider,
@@ -21,33 +22,118 @@ pub enum PreparedGlyph {
     // TODO: Image and Colr variants.
 }
 
-/// Returns an iterator over the renderable glyphs in the given run.
-pub fn iter_renderable_glyphs(run: &GlyphRun) -> impl Iterator<Item = PreparedGlyph> + '_ {
-    let font = skrifa::FontRef::from_index(run.font.data.as_ref(), run.font.index).unwrap();
-    let outlines = font.outline_glyphs();
-    let size = Size::new(run.font_size);
-    let normalized_coords = run.normalized_coords.as_slice();
-    let hinting_instance = if run.hint {
-        // TODO: Cache hinting instance.
-        Some(HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).unwrap())
-    } else {
-        None
-    };
-    run.glyphs.iter().filter_map(move |glyph| {
-        let draw_settings = if let Some(hinting_instance) = &hinting_instance {
-            DrawSettings::hinted(&hinting_instance, false)
-        } else {
-            DrawSettings::unhinted(size, normalized_coords)
-        };
-        let outline = outlines.get(GlyphId::new(glyph.id))?;
-        let mut path = OutlinePath(BezPath::new());
-        outline.draw(draw_settings, &mut path).ok()?;
-        let transform = run
-            .transform
-            .then_translate(Vec2::new(glyph.x as f64, glyph.y as f64));
-        Some(PreparedGlyph::Contour((path.0, transform)))
-    })
+/// A sequence of glyphs with shared rendering properties.
+#[derive(Clone, Debug)]
+pub struct GlyphRun {
+    /// Font for all glyphs in the run.
+    pub font: Font,
+    /// Size of the font in pixels per em.
+    pub font_size: f32,
+    /// Normalized variation coordinates for variable fonts.
+    pub normalized_coords: Vec<NormalizedCoord>,
+    /// Controls whether font hinting is enabled.
+    pub hint: bool,
 }
+
+/// Trait for types that can render glyphs.
+pub trait GlyphRenderer {
+    /// Fill glyphs with the current paint and fill rule.
+    fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>);
+
+    /// Stroke glyphs with the current paint and stroke settings.
+    fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>);
+}
+
+/// A builder for configuring and drawing glyphs.
+#[derive(Debug)]
+pub struct DrawGlyphs<'a, T: GlyphRenderer + 'a> {
+    run: GlyphRun,
+    renderer: &'a mut T,
+}
+
+impl<'a, T: GlyphRenderer + 'a> DrawGlyphs<'a, T> {
+    /// Creates a new builder for drawing glyphs.
+    pub fn new(font: Font, renderer: &'a mut T) -> Self {
+        Self {
+            run: GlyphRun {
+                font,
+                font_size: 16.0,
+                hint: true,
+                normalized_coords: Vec::new(),
+            },
+            renderer,
+        }
+    }
+
+    /// Set the font size in pixels per em.
+    pub fn font_size(mut self, size: f32) -> Self {
+        self.run.font_size = size;
+        self
+    }
+
+    /// Set whether font hinting is enabled.
+    pub fn hint(mut self, hint: bool) -> Self {
+        self.run.hint = hint;
+        self
+    }
+
+    /// Set normalized variation coordinates for variable fonts.
+    pub fn normalized_coords(mut self, coords: Vec<NormalizedCoord>) -> Self {
+        self.run.normalized_coords = coords;
+        self
+    }
+
+    /// Consumes the builder and fills the glyphs with the current configuration.
+    pub fn fill_glyphs(self, glyphs: impl Iterator<Item = &'a Glyph>) {
+        self.renderer
+            .fill_glyphs(Self::prepare_glyphs(&self.run, glyphs));
+    }
+
+    /// Consumes the builder and strokes the glyphs with the current configuration.
+    pub fn stroke_glyphs(self, glyphs: impl Iterator<Item = &'a Glyph>) {
+        self.renderer
+            .stroke_glyphs(Self::prepare_glyphs(&self.run, glyphs));
+    }
+
+    fn prepare_glyphs(
+        run: &GlyphRun,
+        glyphs: impl Iterator<Item = &'a Glyph>,
+    ) -> impl Iterator<Item = PreparedGlyph> {
+        let font = skrifa::FontRef::from_index(run.font.data.as_ref(), run.font.index).unwrap();
+        let outlines = font.outline_glyphs();
+        let size = Size::new(run.font_size);
+        let normalized_coords = run.normalized_coords.as_slice();
+        let hinting_instance = if run.hint {
+            // TODO: Cache hinting instance.
+            Some(HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).unwrap())
+        } else {
+            None
+        };
+        glyphs.filter_map(move |glyph| {
+            let draw_settings = if let Some(hinting_instance) = &hinting_instance {
+                DrawSettings::hinted(&hinting_instance, false)
+            } else {
+                DrawSettings::unhinted(size, normalized_coords)
+            };
+            let outline = outlines.get(GlyphId::new(glyph.id))?;
+            let mut path = OutlinePath(BezPath::new());
+            outline.draw(draw_settings, &mut path).ok()?;
+            let transform = Affine::translate(Vec2::new(glyph.x as f64, glyph.y as f64));
+            Some(PreparedGlyph::Contour((path.0, transform)))
+        })
+    }
+}
+
+// TODO: Although these are sane defaults, we might want to make them
+// configurable.
+const HINTING_OPTIONS: HintingOptions = HintingOptions {
+    engine: skrifa::outline::Engine::AutoFallback,
+    target: skrifa::outline::Target::Smooth {
+        mode: skrifa::outline::SmoothMode::Lcd,
+        symmetric_rendering: false,
+        preserve_linear_metrics: true,
+    },
+};
 
 struct OutlinePath(BezPath);
 
@@ -77,13 +163,3 @@ impl OutlinePen for OutlinePath {
         self.0.close_path();
     }
 }
-
-// TODO: Make this configurable.
-const HINTING_OPTIONS: HintingOptions = HintingOptions {
-    engine: skrifa::outline::Engine::AutoFallback,
-    target: skrifa::outline::Target::Smooth {
-        mode: skrifa::outline::SmoothMode::Lcd,
-        symmetric_rendering: false,
-        preserve_linear_metrics: true,
-    },
-};

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -17,14 +17,14 @@ pub use vello_api::glyph::*;
 /// A glyph prepared for rendering.
 #[derive(Debug)]
 pub enum PreparedGlyph {
-    /// A contour glyph.
-    Contour(ContourGlyph),
+    /// A glyph defined by its outline.
+    Outline(OutlineGlyph),
     // TODO: Image and Colr variants.
 }
 
 /// A glyph defined by a path (its outline) and a local transform.
 #[derive(Debug)]
-pub struct ContourGlyph {
+pub struct OutlineGlyph {
     /// The path of the glyph.
     pub path: BezPath,
     /// The local transform of the glyph.
@@ -121,7 +121,7 @@ impl<'a, T: GlyphRenderer + 'a> DrawGlyphs<'a, T> {
             let mut path = OutlinePath(BezPath::new());
             outline.draw(draw_settings, &mut path).ok()?;
             let transform = Affine::translate(Vec2::new(glyph.x as f64, glyph.y as f64));
-            Some(PreparedGlyph::Contour(ContourGlyph {
+            Some(PreparedGlyph::Outline(OutlineGlyph {
                 path: path.0,
                 local_transform: transform,
             }))

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -105,7 +105,11 @@ impl<'a, T: GlyphRenderer + 'a> DrawGlyphs<'a, T> {
         let normalized_coords = run.normalized_coords.as_slice();
         let hinting_instance = if run.hint {
             // TODO: Cache hinting instance.
-            Some(HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).unwrap())
+            if let Some(instance) = HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).ok() {
+                Some(instance)
+            } else {
+                None
+            }
         } else {
             None
         };

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -31,19 +31,6 @@ pub struct ContourGlyph {
     pub local_transform: Affine,
 }
 
-/// A sequence of glyphs with shared rendering properties.
-#[derive(Clone, Debug)]
-pub struct GlyphRun {
-    /// Font for all glyphs in the run.
-    pub font: Font,
-    /// Size of the font in pixels per em.
-    pub font_size: f32,
-    /// Normalized variation coordinates for variable fonts.
-    pub normalized_coords: Vec<NormalizedCoord>,
-    /// Controls whether font hinting is enabled.
-    pub hint: bool,
-}
-
 /// Trait for types that can render glyphs.
 pub trait GlyphRenderer {
     /// Fill glyphs with the current paint and fill rule.
@@ -140,6 +127,19 @@ impl<'a, T: GlyphRenderer + 'a> DrawGlyphs<'a, T> {
             }))
         })
     }
+}
+
+/// A sequence of glyphs with shared rendering properties.
+#[derive(Clone, Debug)]
+struct GlyphRun {
+    /// Font for all glyphs in the run.
+    pub font: Font,
+    /// Size of the font in pixels per em.
+    pub font_size: f32,
+    /// Normalized variation coordinates for variable fonts.
+    pub normalized_coords: Vec<NormalizedCoord>,
+    /// Controls whether font hinting is enabled.
+    pub hint: bool,
 }
 
 // TODO: Although these are sane defaults, we might want to make them

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -155,6 +155,7 @@ const HINTING_OPTIONS: HintingOptions = HintingOptions {
 
 struct OutlinePath(BezPath);
 
+// Flips the y-axis to match our coordinate system.
 impl OutlinePen for OutlinePath {
     #[inline]
     fn move_to(&mut self, x: f32, y: f32) {

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -1,0 +1,88 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Processing and drawing glyphs.
+
+use skrifa::instance::Size;
+use skrifa::outline::DrawSettings;
+use skrifa::{
+    GlyphId, MetadataProvider,
+    outline::{HintingInstance, HintingOptions, OutlinePen},
+};
+use vello_api::kurbo::{Affine, BezPath, Vec2};
+
+pub use vello_api::glyph::*;
+
+/// A glyph prepared for rendering.
+#[derive(Debug)]
+pub enum PreparedGlyph {
+    /// A contour glyph.
+    Contour((BezPath, Affine)),
+    // TODO: Image and Colr variants.
+}
+
+/// Returns an iterator over the renderable glyphs in the given run.
+pub fn iter_renderable_glyphs(run: &GlyphRun) -> impl Iterator<Item = PreparedGlyph> + '_ {
+    let font = skrifa::FontRef::from_index(run.font.data.as_ref(), run.font.index).unwrap();
+    let outlines = font.outline_glyphs();
+    let size = Size::new(run.font_size);
+    let normalized_coords = run.normalized_coords.as_slice();
+    let hinting_instance = if run.hint {
+        // TODO: Cache hinting instance.
+        Some(HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).unwrap())
+    } else {
+        None
+    };
+    run.glyphs.iter().filter_map(move |glyph| {
+        let draw_settings = if let Some(hinting_instance) = &hinting_instance {
+            DrawSettings::hinted(&hinting_instance, false)
+        } else {
+            DrawSettings::unhinted(size, normalized_coords)
+        };
+        let outline = outlines.get(GlyphId::new(glyph.id))?;
+        let mut path = OutlinePath(BezPath::new());
+        outline.draw(draw_settings, &mut path).ok()?;
+        let transform = run
+            .transform
+            .then_translate(Vec2::new(glyph.x as f64, glyph.y as f64));
+        Some(PreparedGlyph::Contour((path.0, transform)))
+    })
+}
+
+struct OutlinePath(BezPath);
+
+impl OutlinePen for OutlinePath {
+    #[inline]
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.0.move_to((x, -y));
+    }
+
+    #[inline]
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.0.line_to((x, -y));
+    }
+
+    #[inline]
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        self.0.curve_to((cx0, -cy0), (cx1, -cy1), (x, -y));
+    }
+
+    #[inline]
+    fn quad_to(&mut self, cx: f32, cy: f32, x: f32, y: f32) {
+        self.0.quad_to((cx, -cy), (x, -y));
+    }
+
+    #[inline]
+    fn close(&mut self) {
+        self.0.close_path();
+    }
+}
+
+const HINTING_OPTIONS: HintingOptions = HintingOptions {
+    engine: skrifa::outline::Engine::AutoFallback,
+    target: skrifa::outline::Target::Smooth {
+        mode: skrifa::outline::SmoothMode::Lcd,
+        symmetric_rendering: false,
+        preserve_linear_metrics: true,
+    },
+};

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -42,12 +42,12 @@ pub trait GlyphRenderer {
 
 /// A builder for configuring and drawing glyphs.
 #[derive(Debug)]
-pub struct DrawGlyphs<'a, T: GlyphRenderer + 'a> {
+pub struct GlyphRunBuilder<'a, T: GlyphRenderer + 'a> {
     run: GlyphRun,
     renderer: &'a mut T,
 }
 
-impl<'a, T: GlyphRenderer + 'a> DrawGlyphs<'a, T> {
+impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
     /// Creates a new builder for drawing glyphs.
     pub fn new(font: Font, renderer: &'a mut T) -> Self {
         Self {

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -149,7 +149,7 @@ const HINTING_OPTIONS: HintingOptions = HintingOptions {
 
 struct OutlinePath(BezPath);
 
-// Flips the y-axis to match our coordinate system.
+// Note that we flip the y-axis to match our coordinate system.
 impl OutlinePen for OutlinePath {
     #[inline]
     fn move_to(&mut self, x: f32, y: f32) {

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -18,8 +18,17 @@ pub use vello_api::glyph::*;
 #[derive(Debug)]
 pub enum PreparedGlyph {
     /// A contour glyph.
-    Contour((BezPath, Affine)),
+    Contour(ContourGlyph),
     // TODO: Image and Colr variants.
+}
+
+/// A glyph defined by a path (its outline) and a local transform.
+#[derive(Debug)]
+pub struct ContourGlyph {
+    /// The path of the glyph.
+    pub path: BezPath,
+    /// The local transform of the glyph.
+    pub local_transform: Affine,
 }
 
 /// A sequence of glyphs with shared rendering properties.
@@ -105,7 +114,9 @@ impl<'a, T: GlyphRenderer + 'a> DrawGlyphs<'a, T> {
         let normalized_coords = run.normalized_coords.as_slice();
         let hinting_instance = if run.hint {
             // TODO: Cache hinting instance.
-            if let Some(instance) = HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).ok() {
+            if let Some(instance) =
+                HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).ok()
+            {
                 Some(instance)
             } else {
                 None

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -134,7 +134,10 @@ impl<'a, T: GlyphRenderer + 'a> DrawGlyphs<'a, T> {
             let mut path = OutlinePath(BezPath::new());
             outline.draw(draw_settings, &mut path).ok()?;
             let transform = Affine::translate(Vec2::new(glyph.x as f64, glyph.y as f64));
-            Some(PreparedGlyph::Contour((path.0, transform)))
+            Some(PreparedGlyph::Contour(ContourGlyph {
+                path: path.0,
+                local_transform: transform,
+            }))
         })
     }
 }

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -101,19 +101,13 @@ impl<'a, T: GlyphRenderer + 'a> DrawGlyphs<'a, T> {
         let normalized_coords = run.normalized_coords.as_slice();
         let hinting_instance = if run.hint {
             // TODO: Cache hinting instance.
-            if let Some(instance) =
-                HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).ok()
-            {
-                Some(instance)
-            } else {
-                None
-            }
+            HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).ok()
         } else {
             None
         };
         glyphs.filter_map(move |glyph| {
             let draw_settings = if let Some(hinting_instance) = &hinting_instance {
-                DrawSettings::hinted(&hinting_instance, false)
+                DrawSettings::hinted(hinting_instance, false)
             } else {
                 DrawSettings::unhinted(size, normalized_coords)
             };

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -14,6 +14,7 @@ only break in edge cases, and some of them are also only related to conversions 
 
 pub mod coarse;
 pub mod flatten;
+pub mod glyph;
 pub mod pico_svg;
 pub mod pixmap;
 pub mod strip;

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -17,6 +17,7 @@ vello_common = { workspace = true }
 [dev-dependencies]
 oxipng = { workspace = true, features = ["freestanding", "parallel"] }
 image = { workspace = true, features = ["png"] }
+skrifa = { workspace = true }
 
 [lints]
 workspace = true

--- a/sparse_strips/vello_cpu/snapshots/filled_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/filled_glyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a876a4537bdc5812158aff76475b4e50ca70a8423c3e418bd8a640ca43b218e
+size 2391

--- a/sparse_strips/vello_cpu/snapshots/skewed_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/skewed_glyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ba918c5de97f7b2dbdb7e282cd2f57b26fd0d8b43e576c388a738b01462df79
+size 3161

--- a/sparse_strips/vello_cpu/snapshots/stroked_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/stroked_glyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbed811f8c94c1cea5b7dbe17fb69b83b66f47cef0a59ba678b55225f13dfe24
+size 3343

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -6,7 +6,7 @@
 use crate::fine::Fine;
 use vello_common::coarse::Wide;
 use vello_common::flatten::Line;
-use vello_common::glyph::{DrawGlyphs, GlyphRenderer, PreparedGlyph};
+use vello_common::glyph::{GlyphRenderer, GlyphRunBuilder, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
 use vello_common::peniko::Font;
@@ -96,8 +96,8 @@ impl RenderContext {
     }
 
     /// Create a builder for drawing glyphs.
-    pub fn draw_glyphs(&mut self, font: &Font) -> DrawGlyphs<'_, Self> {
-        DrawGlyphs::new(font.clone(), self)
+    pub fn glyph_run(&mut self, font: &Font) -> GlyphRunBuilder<'_, Self> {
+        GlyphRunBuilder::new(font.clone(), self)
     }
 
     /// Set the current blend mode.

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -6,7 +6,7 @@
 use crate::fine::Fine;
 use vello_common::coarse::Wide;
 use vello_common::flatten::Line;
-use vello_common::glyph::{DrawGlyphs, GlyphRenderer, GlyphRun, PreparedGlyph};
+use vello_common::glyph::{DrawGlyphs, GlyphRenderer, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
 use vello_common::peniko::Font;

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -95,7 +95,7 @@ impl RenderContext {
         self.stroke_path(&rect.to_path(DEFAULT_TOLERANCE));
     }
 
-    /// Create a builder for drawing glyphs.
+    /// Creates a builder for drawing a run of glyphs that have the same attributes.
     pub fn glyph_run(&mut self, font: &Font) -> GlyphRunBuilder<'_, Self> {
         GlyphRunBuilder::new(font.clone(), self)
     }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -6,9 +6,10 @@
 use crate::fine::Fine;
 use vello_common::coarse::Wide;
 use vello_common::flatten::Line;
-use vello_common::glyph::{iter_renderable_glyphs, GlyphRun, PreparedGlyph};
+use vello_common::glyph::{DrawGlyphs, GlyphRenderer, GlyphRun, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
+use vello_common::peniko::Font;
 use vello_common::peniko::color::palette::css::BLACK;
 use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::pixmap::Pixmap;
@@ -94,30 +95,9 @@ impl RenderContext {
         self.stroke_path(&rect.to_path(DEFAULT_TOLERANCE));
     }
 
-    /// Fills a glyph run with the current paint and fill rule.
-    pub fn fill_glyphs(&mut self, run: &GlyphRun) {
-        for glyph in iter_renderable_glyphs(run) {
-            match glyph {
-                PreparedGlyph::Contour((path, transform)) => {
-                    let transform = self.transform * transform;
-                    flatten::fill(&path, transform, &mut self.line_buf);
-                    self.render_path(self.fill_rule, self.paint.clone());
-                }
-            }
-        }
-    }
-
-    /// Strokes a glyph run with the current paint and fill rule.
-    pub fn stroke_glyphs(&mut self, run: &GlyphRun) {
-        for glyph in iter_renderable_glyphs(run) {
-            match glyph {
-                PreparedGlyph::Contour((path, transform)) => {
-                    let transform = self.transform * transform;
-                    flatten::stroke(&path, &self.stroke, transform, &mut self.line_buf);
-                    self.render_path(Fill::NonZero, self.paint.clone());
-                }
-            }
-        }
+    /// Create a builder for drawing glyphs.
+    pub fn draw_glyphs(&mut self, font: &Font) -> DrawGlyphs<'_, Self> {
+        DrawGlyphs::new(font.clone(), self)
     }
 
     /// Set the current blend mode.
@@ -199,5 +179,31 @@ impl RenderContext {
         );
 
         self.wide.generate(&self.strip_buf, fill_rule, paint);
+    }
+}
+
+impl GlyphRenderer for RenderContext {
+    fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
+        for glyph in glyphs {
+            match glyph {
+                PreparedGlyph::Contour((path, transform)) => {
+                    let transform = self.transform * transform;
+                    flatten::fill(&path, transform, &mut self.line_buf);
+                    self.render_path(self.fill_rule, self.paint.clone());
+                }
+            }
+        }
+    }
+
+    fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
+        for glyph in glyphs {
+            match glyph {
+                PreparedGlyph::Contour((path, transform)) => {
+                    let transform = self.transform * transform;
+                    flatten::stroke(&path, &self.stroke, transform, &mut self.line_buf);
+                    self.render_path(Fill::NonZero, self.paint.clone());
+                }
+            }
+        }
     }
 }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -186,7 +186,7 @@ impl GlyphRenderer for RenderContext {
     fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
         for glyph in glyphs {
             match glyph {
-                PreparedGlyph::Contour(glyph) => {
+                PreparedGlyph::Outline(glyph) => {
                     let transform = self.transform * glyph.local_transform;
                     flatten::fill(&glyph.path, transform, &mut self.line_buf);
                     self.render_path(self.fill_rule, self.paint.clone());
@@ -198,7 +198,7 @@ impl GlyphRenderer for RenderContext {
     fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
         for glyph in glyphs {
             match glyph {
-                PreparedGlyph::Contour(glyph) => {
+                PreparedGlyph::Outline(glyph) => {
                     let transform = self.transform * glyph.local_transform;
                     flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
                     self.render_path(Fill::NonZero, self.paint.clone());

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -186,9 +186,9 @@ impl GlyphRenderer for RenderContext {
     fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
         for glyph in glyphs {
             match glyph {
-                PreparedGlyph::Contour((path, transform)) => {
-                    let transform = self.transform * transform;
-                    flatten::fill(&path, transform, &mut self.line_buf);
+                PreparedGlyph::Contour(glyph) => {
+                    let transform = self.transform * glyph.local_transform;
+                    flatten::fill(&glyph.path, transform, &mut self.line_buf);
                     self.render_path(self.fill_rule, self.paint.clone());
                 }
             }
@@ -198,9 +198,9 @@ impl GlyphRenderer for RenderContext {
     fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
         for glyph in glyphs {
             match glyph {
-                PreparedGlyph::Contour((path, transform)) => {
-                    let transform = self.transform * transform;
-                    flatten::stroke(&path, &self.stroke, transform, &mut self.line_buf);
+                PreparedGlyph::Contour(glyph) => {
+                    let transform = self.transform * glyph.local_transform;
+                    flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
                     self.render_path(Fill::NonZero, self.paint.clone());
                 }
             }

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -556,6 +556,22 @@ fn stroked_glyphs() {
     check_ref(&ctx, "stroked_glyphs");
 }
 
+#[test]
+fn skewed_glyphs() {
+    let mut ctx = get_ctx(300, 70, false);
+    let font_size: f32 = 50_f32;
+    let (font, glyphs) = layout_glyphs("Hello, world!", font_size);
+
+    ctx.set_transform(Affine::translate((0., f64::from(font_size))));
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.glyph_run(&font)
+        .font_size(font_size)
+        .glyph_transform(Affine::skew(-20_f64.to_radians().tan(), 0.0))
+        .fill_glyphs(glyphs.iter());
+
+    check_ref(&ctx, "skewed_glyphs");
+}
+
 fn layout_glyphs(text: &str, font_size: f32) -> (Font, Vec<Glyph>) {
     const ROBOTO_FONT: &[u8] = include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
     let font = Font::new(Blob::new(Arc::new(ROBOTO_FONT)), 0);

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -4,13 +4,17 @@
 //! Tests for basic functionality.
 
 use crate::util::{check_ref, get_ctx, render_pixmap};
+use skrifa::MetadataProvider;
+use skrifa::raw::FileRef;
 use std::f64::consts::PI;
+use std::sync::Arc;
 use vello_common::color::palette::css::{
     BEIGE, BLUE, DARK_GREEN, GREEN, LIME, MAROON, REBECCA_PURPLE, RED, YELLOW,
 };
+use vello_common::glyph::Glyph;
 use vello_common::kurbo::{Affine, BezPath, Circle, Join, Point, Rect, Shape, Stroke};
 use vello_common::peniko;
-use vello_common::peniko::Compose;
+use vello_common::peniko::{Blob, Compose, Font};
 use vello_cpu::RenderContext;
 
 mod util;
@@ -520,6 +524,82 @@ fn filled_vertical_hairline_rect_2() {
     ctx.fill_rect(&rect);
 
     check_ref(&ctx, "filled_vertical_hairline_rect_2");
+}
+
+#[test]
+fn filled_glyphs() {
+    let mut ctx = get_ctx(300, 70, false);
+    let font_size: f32 = 50_f32;
+    let (font, glyphs) = layout_glyphs("Hello, world!", font_size);
+
+    ctx.set_transform(Affine::translate((0., f64::from(font_size))));
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.glyph_run(&font)
+        .font_size(font_size)
+        .fill_glyphs(glyphs.iter());
+
+    check_ref(&ctx, "filled_glyphs");
+}
+
+#[test]
+fn stroked_glyphs() {
+    let mut ctx = get_ctx(300, 70, false);
+    let font_size: f32 = 50_f32;
+    let (font, glyphs) = layout_glyphs("Hello, world!", font_size);
+
+    ctx.set_transform(Affine::translate((0., f64::from(font_size))));
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.glyph_run(&font)
+        .font_size(font_size)
+        .stroke_glyphs(glyphs.iter());
+
+    check_ref(&ctx, "stroked_glyphs");
+}
+
+fn layout_glyphs(text: &str, font_size: f32) -> (Font, Vec<Glyph>) {
+    const ROBOTO_FONT: &[u8] = include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
+    let font = Font::new(Blob::new(Arc::new(ROBOTO_FONT)), 0);
+
+    let font_ref = {
+        let file_ref = FileRef::new(font.data.as_ref()).unwrap();
+        match file_ref {
+            FileRef::Font(f) => f,
+            FileRef::Collection(collection) => collection.get(font.index).unwrap(),
+        }
+    };
+    let font_size = skrifa::instance::Size::new(font_size);
+    let axes = font_ref.axes();
+    let variations: Vec<(&str, f32)> = vec![];
+    let var_loc = axes.location(variations.as_slice());
+    let charmap = font_ref.charmap();
+    let metrics = font_ref.metrics(font_size, &var_loc);
+    let line_height = metrics.ascent - metrics.descent + metrics.leading;
+    let glyph_metrics = font_ref.glyph_metrics(font_size, &var_loc);
+
+    let mut pen_x = 0_f32;
+    let mut pen_y = 0_f32;
+
+    let glyphs = text
+        .chars()
+        .filter_map(|ch| {
+            if ch == '\n' {
+                pen_y += line_height;
+                pen_x = 0.0;
+                return None;
+            }
+            let gid = charmap.map(ch).unwrap_or_default();
+            let advance = glyph_metrics.advance_width(gid).unwrap_or_default();
+            let x = pen_x;
+            pen_x += advance;
+            Some(Glyph {
+                id: gid.to_u32(),
+                x,
+                y: pen_y,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    (font, glyphs)
 }
 
 fn miter_stroke_2() -> Stroke {

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -21,6 +21,7 @@ wgpu = { workspace = true }
 
 [dev-dependencies]
 winit = "0.30.9"
+skrifa = { workspace = true }
 pollster = { workspace = true }
 png = "0.17.14"
 roxmltree = "0.20.0"

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -223,6 +223,7 @@ fn draw_text(ctx: &mut Scene) {
     let transform = Affine::scale(2.0).then_translate((0., f64::from(size) * 2.0).into());
     ctx.set_transform(transform);
 
+    // Fill the text
     ctx.glyph_run(&font)
         .normalized_coords(vec![])
         .font_size(size)
@@ -231,8 +232,18 @@ fn draw_text(ctx: &mut Scene) {
 
     ctx.set_transform(transform.then_translate((0., f64::from(size) * 2.0).into()));
 
+    // Stroke the text
     ctx.glyph_run(&font)
         .font_size(size)
+        .hint(true)
+        .stroke_glyphs(glyphs.iter());
+
+    ctx.set_transform(transform.then_translate((0., f64::from(size) * 4.0).into()));
+
+    // Skew the text to the right
+    ctx.glyph_run(&font)
+        .font_size(size)
+        .glyph_transform(Affine::skew(-20_f64.to_radians().tan(), 0.0))
         .hint(true)
         .stroke_glyphs(glyphs.iter());
 }

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -223,7 +223,7 @@ fn draw_text(ctx: &mut Scene) {
     let transform = Affine::scale(2.0).then_translate((0., f64::from(size) * 2.0).into());
     ctx.set_transform(transform);
 
-    ctx.draw_glyphs(&font)
+    ctx.glyph_run(&font)
         .normalized_coords(vec![])
         .font_size(size)
         .hint(true)
@@ -231,7 +231,7 @@ fn draw_text(ctx: &mut Scene) {
 
     ctx.set_transform(transform.then_translate((0., f64::from(size) * 2.0).into()));
 
-    ctx.draw_glyphs(&font)
+    ctx.glyph_run(&font)
         .font_size(size)
         .hint(true)
         .stroke_glyphs(glyphs.iter());

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -10,9 +10,9 @@ use skrifa::raw::FileRef;
 use skrifa::{FontRef, MetadataProvider};
 use std::sync::Arc;
 use vello_common::glyph::{Glyph, GlyphRun};
-use vello_common::kurbo::Affine;
-use vello_common::peniko::{Blob, Font};
+use vello_common::kurbo::{Affine, Rect};
 use vello_common::peniko::color::palette;
+use vello_common::peniko::{Blob, Font};
 use vello_hybrid::{RenderParams, Renderer, Scene};
 use wgpu::RenderPassDescriptor;
 use winit::{
@@ -214,25 +214,20 @@ fn draw_text(ctx: &mut Scene) {
         .collect::<Vec<_>>();
 
     ctx.set_paint(palette::css::WHITE.into());
-    ctx.set_transform(Affine::translate((0., f64::from(size))));
+    let transform = Affine::scale(2.0).then_translate((0., f64::from(size) * 2.0).into());
+    ctx.set_transform(transform);
 
-    ctx.fill_glyphs(&GlyphRun {
-        glyphs: glyphs.clone(),
-        font: font.clone(),
-        font_size: size,
-        transform: Affine::default(),
-        normalized_coords: vec![],
-        hint: true,
-    });
+    ctx.draw_glyphs(&font)
+        .font_size(size)
+        .hint(true)
+        .fill_glyphs(glyphs.iter());
 
-    ctx.stroke_glyphs(&GlyphRun {
-        glyphs,
-        font,
-        font_size: size,
-        transform: Affine::translate((0., 2. * f64::from(size))),
-        normalized_coords: vec![],
-        hint: true,
-    });
+    ctx.set_transform(transform.then_translate((0., f64::from(size) * 2.0).into()));
+
+    ctx.draw_glyphs(&font)
+        .font_size(size)
+        .hint(true)
+        .stroke_glyphs(glyphs.iter());
 }
 
 fn to_font_ref(font: &Font) -> Option<FontRef<'_>> {

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -177,7 +177,13 @@ impl ApplicationHandler for App<'_> {
 
 fn draw_text(ctx: &mut Scene) {
     let font = Font::new(Blob::new(Arc::new(ROBOTO_FONT)), 0);
-    let font_ref = to_font_ref(&font).unwrap();
+    let font_ref = {
+        let file_ref = FileRef::new(font.data.as_ref()).unwrap();
+        match file_ref {
+            FileRef::Font(f) => f,
+            FileRef::Collection(collection) => collection.get(font.index).unwrap(),
+        }
+    };
     let axes = font_ref.axes();
     let size = 52_f32;
     let font_size = skrifa::instance::Size::new(size);
@@ -193,12 +199,6 @@ fn draw_text(ctx: &mut Scene) {
 
     let text = "Hello, world!";
 
-    // A Vec of Glyphs:
-    // Vec<Glyph {
-    //     id: GlyphId,
-    //     x: f32,
-    //     y: f32,
-    // }>
     let glyphs = text
         .chars()
         .filter_map(|ch| {
@@ -235,12 +235,4 @@ fn draw_text(ctx: &mut Scene) {
         .font_size(size)
         .hint(true)
         .stroke_glyphs(glyphs.iter());
-}
-
-fn to_font_ref(font: &Font) -> Option<FontRef<'_>> {
-    let file_ref = FileRef::new(font.data.as_ref()).ok()?;
-    match file_ref {
-        FileRef::Font(f) => Some(f),
-        FileRef::Collection(collection) => collection.get(font.index).ok(),
-    }
 }

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -12,10 +12,7 @@ use std::sync::Arc;
 use vello_common::glyph::{Glyph, GlyphRun};
 use vello_common::kurbo::Affine;
 use vello_common::peniko::{Blob, Font};
-use vello_common::peniko::{
-    color::palette,
-    kurbo::{BezPath, Stroke},
-};
+use vello_common::peniko::color::palette;
 use vello_hybrid::{RenderParams, Renderer, Scene};
 use wgpu::RenderPassDescriptor;
 use winit::{
@@ -27,10 +24,8 @@ use winit::{
 
 const ROBOTO_FONT: &[u8] = include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
 
-/// Main entry point for the simple GPU renderer example.
-/// Creates a window and continuously renders a simple scene using the hybrid CPU/GPU renderer.
 fn main() {
-    let mut app = SimpleVelloApp {
+    let mut app = App {
         context: RenderContext::new(),
         renderers: vec![],
         state: RenderState::Suspended(None),
@@ -52,14 +47,14 @@ enum RenderState<'s> {
     Suspended(Option<Arc<Window>>),
 }
 
-struct SimpleVelloApp<'s> {
+struct App<'s> {
     context: RenderContext,
     renderers: Vec<Option<Renderer>>,
     state: RenderState<'s>,
     scene: Scene,
 }
 
-impl ApplicationHandler for SimpleVelloApp<'_> {
+impl ApplicationHandler for App<'_> {
     fn suspended(&mut self, _event_loop: &ActiveEventLoop) {
         if let RenderState::Active { window, .. } = &self.state {
             self.state = RenderState::Suspended(Some(window.clone()));
@@ -180,7 +175,6 @@ impl ApplicationHandler for SimpleVelloApp<'_> {
     }
 }
 
-/// Draws a simple scene with shapes
 fn draw_text(ctx: &mut Scene) {
     let font = Font::new(Blob::new(Arc::new(ROBOTO_FONT)), 0);
     let font_ref = to_font_ref(&font).unwrap();
@@ -193,6 +187,7 @@ fn draw_text(ctx: &mut Scene) {
     let metrics = font_ref.metrics(font_size, &var_loc);
     let line_height = metrics.ascent - metrics.descent + metrics.leading;
     let glyph_metrics = font_ref.glyph_metrics(font_size, &var_loc);
+
     let mut pen_x = 0_f32;
     let mut pen_y = 0_f32;
 

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -240,7 +240,7 @@ fn draw_text(ctx: &mut Scene) {
 fn to_font_ref(font: &Font) -> Option<FontRef<'_>> {
     let file_ref = FileRef::new(font.data.as_ref()).ok()?;
     match file_ref {
-        FileRef::Font(font) => Some(font),
+        FileRef::Font(f) => Some(f),
         FileRef::Collection(collection) => collection.get(font.index).ok(),
     }
 }

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -9,8 +9,8 @@ use common::{RenderContext, RenderSurface, create_vello_renderer, create_winit_w
 use skrifa::raw::FileRef;
 use skrifa::{FontRef, MetadataProvider};
 use std::sync::Arc;
-use vello_common::glyph::{Glyph, GlyphRun};
-use vello_common::kurbo::{Affine, Rect};
+use vello_common::glyph::Glyph;
+use vello_common::kurbo::Affine;
 use vello_common::peniko::color::palette;
 use vello_common::peniko::{Blob, Font};
 use vello_hybrid::{RenderParams, Renderer, Scene};

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -6,8 +6,8 @@
 mod common;
 
 use common::{RenderContext, RenderSurface, create_vello_renderer, create_winit_window};
+use skrifa::MetadataProvider;
 use skrifa::raw::FileRef;
-use skrifa::{FontRef, MetadataProvider};
 use std::sync::Arc;
 use vello_common::glyph::Glyph;
 use vello_common::kurbo::Affine;

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -1,0 +1,249 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Draws some text on screen.
+
+mod common;
+
+use common::{RenderContext, RenderSurface, create_vello_renderer, create_winit_window};
+use skrifa::raw::FileRef;
+use skrifa::{FontRef, MetadataProvider};
+use std::sync::Arc;
+use vello_common::glyph::{Glyph, GlyphRun};
+use vello_common::kurbo::Affine;
+use vello_common::peniko::{Blob, Font};
+use vello_common::peniko::{
+    color::palette,
+    kurbo::{BezPath, Stroke},
+};
+use vello_hybrid::{RenderParams, Renderer, Scene};
+use wgpu::RenderPassDescriptor;
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::{ActiveEventLoop, EventLoop},
+    window::{Window, WindowId},
+};
+
+const ROBOTO_FONT: &[u8] = include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
+
+/// Main entry point for the simple GPU renderer example.
+/// Creates a window and continuously renders a simple scene using the hybrid CPU/GPU renderer.
+fn main() {
+    let mut app = SimpleVelloApp {
+        context: RenderContext::new(),
+        renderers: vec![],
+        state: RenderState::Suspended(None),
+        scene: Scene::new(900, 600),
+    };
+
+    let event_loop = EventLoop::new().unwrap();
+    event_loop
+        .run_app(&mut app)
+        .expect("Couldn't run event loop");
+}
+
+#[derive(Debug)]
+enum RenderState<'s> {
+    Active {
+        surface: Box<RenderSurface<'s>>,
+        window: Arc<Window>,
+    },
+    Suspended(Option<Arc<Window>>),
+}
+
+struct SimpleVelloApp<'s> {
+    context: RenderContext,
+    renderers: Vec<Option<Renderer>>,
+    state: RenderState<'s>,
+    scene: Scene,
+}
+
+impl ApplicationHandler for SimpleVelloApp<'_> {
+    fn suspended(&mut self, _event_loop: &ActiveEventLoop) {
+        if let RenderState::Active { window, .. } = &self.state {
+            self.state = RenderState::Suspended(Some(window.clone()));
+        }
+    }
+
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let RenderState::Suspended(cached_window) = &mut self.state else {
+            return;
+        };
+
+        let window = cached_window.take().unwrap_or_else(|| {
+            create_winit_window(
+                event_loop,
+                self.scene.width().into(),
+                self.scene.height().into(),
+                true,
+            )
+        });
+
+        let size = window.inner_size();
+        let surface = pollster::block_on(self.context.create_surface(
+            window.clone(),
+            size.width,
+            size.height,
+            wgpu::PresentMode::AutoVsync,
+            wgpu::TextureFormat::Bgra8Unorm,
+        ));
+
+        self.renderers
+            .resize_with(self.context.devices.len(), || None);
+        self.renderers[surface.dev_id]
+            .get_or_insert_with(|| create_vello_renderer(&self.context, &surface));
+
+        self.state = RenderState::Active {
+            surface: Box::new(surface),
+            window,
+        };
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let surface = match &mut self.state {
+            RenderState::Active { surface, window } if window.id() == window_id => surface,
+            _ => return,
+        };
+
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(size) => {
+                self.context
+                    .resize_surface(surface, size.width, size.height);
+            }
+            WindowEvent::RedrawRequested => {
+                self.scene.reset();
+
+                draw_text(&mut self.scene);
+                let device_handle = &self.context.devices[surface.dev_id];
+                let render_params = RenderParams {
+                    width: surface.config.width,
+                    height: surface.config.height,
+                };
+                self.renderers[surface.dev_id].as_mut().unwrap().prepare(
+                    &device_handle.device,
+                    &device_handle.queue,
+                    &self.scene,
+                    &render_params,
+                );
+
+                let surface_texture = surface
+                    .surface
+                    .get_current_texture()
+                    .expect("failed to get surface texture");
+
+                let texture_view = surface_texture
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+
+                let mut encoder =
+                    device_handle
+                        .device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                            label: Some("Vello Render to Surface pass"),
+                        });
+                {
+                    let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                        label: Some("Render to Texture Pass"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &texture_view,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        occlusion_query_set: None,
+                        timestamp_writes: None,
+                    });
+                    self.renderers[surface.dev_id].as_mut().unwrap().render(
+                        &self.scene,
+                        &mut pass,
+                        &render_params,
+                    );
+                }
+
+                device_handle.queue.submit([encoder.finish()]);
+                surface_texture.present();
+
+                device_handle.device.poll(wgpu::Maintain::Poll);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Draws a simple scene with shapes
+fn draw_text(ctx: &mut Scene) {
+    let font = Font::new(Blob::new(Arc::new(ROBOTO_FONT)), 0);
+    let font_ref = to_font_ref(&font).unwrap();
+    let axes = font_ref.axes();
+    let size = 52_f32;
+    let font_size = skrifa::instance::Size::new(size);
+    let variations: Vec<(&str, f32)> = vec![];
+    let var_loc = axes.location(variations.as_slice());
+    let charmap = font_ref.charmap();
+    let metrics = font_ref.metrics(font_size, &var_loc);
+    let line_height = metrics.ascent - metrics.descent + metrics.leading;
+    let glyph_metrics = font_ref.glyph_metrics(font_size, &var_loc);
+    let mut pen_x = 0_f32;
+    let mut pen_y = 0_f32;
+
+    let text = "Hello, world!";
+
+    let glyphs = text
+        .chars()
+        .filter_map(|ch| {
+            if ch == '\n' {
+                pen_y += line_height;
+                pen_x = 0.0;
+                return None;
+            }
+            let gid = charmap.map(ch).unwrap_or_default();
+            let advance = glyph_metrics.advance_width(gid).unwrap_or_default();
+            let x = pen_x;
+            pen_x += advance;
+            Some(Glyph {
+                id: gid.to_u32(),
+                x,
+                y: pen_y,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    ctx.set_paint(palette::css::WHITE.into());
+    ctx.set_transform(Affine::translate((0., f64::from(size))));
+
+    ctx.fill_glyphs(&GlyphRun {
+        glyphs: glyphs.clone(),
+        font: font.clone(),
+        font_size: size,
+        transform: Affine::default(),
+        normalized_coords: vec![],
+        hint: true,
+    });
+
+    ctx.stroke_glyphs(&GlyphRun {
+        glyphs,
+        font,
+        font_size: size,
+        transform: Affine::translate((0., 2. * f64::from(size))),
+        normalized_coords: vec![],
+        hint: true,
+    });
+}
+
+fn to_font_ref(font: &Font) -> Option<FontRef<'_>> {
+    let file_ref = FileRef::new(font.data.as_ref()).ok()?;
+    match file_ref {
+        FileRef::Font(font) => Some(font),
+        FileRef::Collection(collection) => collection.get(font.index).ok(),
+    }
+}

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -193,6 +193,12 @@ fn draw_text(ctx: &mut Scene) {
 
     let text = "Hello, world!";
 
+    // A Vec of Glyphs:
+    // Vec<Glyph {
+    //     id: GlyphId,
+    //     x: f32,
+    //     y: f32,
+    // }>
     let glyphs = text
         .chars()
         .filter_map(|ch| {
@@ -218,6 +224,7 @@ fn draw_text(ctx: &mut Scene) {
     ctx.set_transform(transform);
 
     ctx.draw_glyphs(&font)
+        .normalized_coords(vec![])
         .font_size(size)
         .hint(true)
         .fill_glyphs(glyphs.iter());

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -271,7 +271,7 @@ impl GlyphRenderer for Scene {
     fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
         for glyph in glyphs {
             match glyph {
-                PreparedGlyph::Contour(glyph) => {
+                PreparedGlyph::Outline(glyph) => {
                     let transform = self.transform * glyph.local_transform;
                     flatten::fill(&glyph.path, transform, &mut self.line_buf);
                     self.render_path(self.fill_rule, self.paint.clone());
@@ -283,7 +283,7 @@ impl GlyphRenderer for Scene {
     fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
         for glyph in glyphs {
             match glyph {
-                PreparedGlyph::Contour(glyph) => {
+                PreparedGlyph::Outline(glyph) => {
                     let transform = self.transform * glyph.local_transform;
                     flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
                     self.render_path(Fill::NonZero, self.paint.clone());

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -115,7 +115,7 @@ impl Scene {
         self.stroke_path(&rect.to_path(DEFAULT_TOLERANCE));
     }
 
-    /// Create a builder for drawing glyphs.
+    /// Creates a builder for drawing a run of glyphs that have the same attributes.
     pub fn glyph_run(&mut self, font: &Font) -> GlyphRunBuilder<'_, Self> {
         GlyphRunBuilder::new(font.clone(), self)
     }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -7,7 +7,7 @@ use crate::render::{GpuStrip, RenderData};
 use vello_common::coarse::{Wide, WideTile};
 use vello_common::color::PremulRgba8;
 use vello_common::flatten::Line;
-use vello_common::glyph::{DrawGlyphs, GlyphRenderer, PreparedGlyph};
+use vello_common::glyph::{GlyphRenderer, GlyphRunBuilder, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
 use vello_common::peniko::Font;
@@ -116,8 +116,8 @@ impl Scene {
     }
 
     /// Create a builder for drawing glyphs.
-    pub fn draw_glyphs(&mut self, font: &Font) -> DrawGlyphs<'_, Self> {
-        DrawGlyphs::new(font.clone(), self)
+    pub fn glyph_run(&mut self, font: &Font) -> GlyphRunBuilder<'_, Self> {
+        GlyphRunBuilder::new(font.clone(), self)
     }
 
     /// Set the blend mode for subsequent rendering operations.

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -271,9 +271,9 @@ impl GlyphRenderer for Scene {
     fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
         for glyph in glyphs {
             match glyph {
-                PreparedGlyph::Contour((path, transform)) => {
-                    let transform = self.transform * transform;
-                    flatten::fill(&path, transform, &mut self.line_buf);
+                PreparedGlyph::Contour(glyph) => {
+                    let transform = self.transform * glyph.local_transform;
+                    flatten::fill(&glyph.path, transform, &mut self.line_buf);
                     self.render_path(self.fill_rule, self.paint.clone());
                 }
             }
@@ -283,9 +283,9 @@ impl GlyphRenderer for Scene {
     fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
         for glyph in glyphs {
             match glyph {
-                PreparedGlyph::Contour((path, transform)) => {
-                    let transform = self.transform * transform;
-                    flatten::stroke(&path, &self.stroke, transform, &mut self.line_buf);
+                PreparedGlyph::Contour(glyph) => {
+                    let transform = self.transform * glyph.local_transform;
+                    flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
                     self.render_path(Fill::NonZero, self.paint.clone());
                 }
             }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -7,7 +7,7 @@ use crate::render::{GpuStrip, RenderData};
 use vello_common::coarse::{Wide, WideTile};
 use vello_common::color::PremulRgba8;
 use vello_common::flatten::Line;
-use vello_common::glyph::{DrawGlyphs, GlyphRenderer, GlyphRun, PreparedGlyph};
+use vello_common::glyph::{DrawGlyphs, GlyphRenderer, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
 use vello_common::peniko::Font;

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -7,6 +7,7 @@ use crate::render::{GpuStrip, RenderData};
 use vello_common::coarse::{Wide, WideTile};
 use vello_common::color::PremulRgba8;
 use vello_common::flatten::Line;
+use vello_common::glyph::{GlyphRun, PreparedGlyph, iter_renderable_glyphs};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
 use vello_common::peniko::color::palette::css::BLACK;
@@ -106,6 +107,32 @@ impl Scene {
     /// Fill a rectangle with the current paint and fill rule.
     pub fn fill_rect(&mut self, rect: &Rect) {
         self.fill_path(&rect.to_path(DEFAULT_TOLERANCE));
+    }
+
+    /// Fills a glyph run with the current paint and fill rule.
+    pub fn fill_glyphs(&mut self, run: &GlyphRun) {
+        for glyph in iter_renderable_glyphs(run) {
+            match glyph {
+                PreparedGlyph::Contour((path, transform)) => {
+                    let transform = self.transform * transform;
+                    flatten::fill(&path, transform, &mut self.line_buf);
+                    self.render_path(self.fill_rule, self.paint.clone());
+                }
+            }
+        }
+    }
+
+    /// Strokes a glyph run with the current paint and fill rule.
+    pub fn stroke_glyphs(&mut self, run: &GlyphRun) {
+        for glyph in iter_renderable_glyphs(run) {
+            match glyph {
+                PreparedGlyph::Contour((path, transform)) => {
+                    let transform = self.transform * transform;
+                    flatten::stroke(&path, &self.stroke, transform, &mut self.line_buf);
+                    self.render_path(Fill::NonZero, self.paint.clone());
+                }
+            }
+        }
     }
 
     /// Stroke a rectangle with the current paint and stroke settings.


### PR DESCRIPTION
## Intent

Adds an API to `vello_cpu` and `vello_hybrid` for drawing text: 

```rs
    // A Vec of glyph positions: Vec<Glyph { id: GlyphId,  x: f32, y: f32 }>
    let glyphs = // ...

    ctx.glyph_run(&font)
        .normalized_coords(...)
        .font_size(size)
        .hint(true)
        .fill_glyphs(glyphs.iter());
```

## Background

This API does not perform text shaping and layout. Those functions should be performed by other libraries like Parley or Cosmic Text. The API proposed here merely takes glyph positions and rendering attributes and renders them to screen.

## Comparison with Vello

The API should feel familiar to Vello's implementation with one change:

- The glyph run doesn't support a global transform as [in Vello](https://github.com/linebender/vello/blob/bf95b8501a9ab92aa5474095cc05dd885588fe1e/vello/src/scene.rs#L380-L383). Happy to change this, but I don't see why the consumer can't use the existing transform API on `Scene`. In other words, the scene's transform applying to every primitive except text seems unexpected and confusing. If text deserves special attention, I'm keen to understand that choice and this PR is certainly flexible to change. (This is my current understanding).

## Design

To support both CPU and Hybrid variants of the renderer, we expose a `GlyphRunBuilder` from `vello_common` that accepts a `GlyphRenderer` trait. The builder encapsulates the logic to "prepare" some glyph for rendering by the `GlyphRenderer`. I've implemented `GlyphRenderer` for both our CPU and Hybrid variants as shown below.

https://github.com/taj-p/vello/blob/6a6d15867376c85b1371f6571208ea7e82dbd770/sparse_strips/vello_cpu/src/render.rs#L185-L209

https://github.com/taj-p/vello/blob/6a6d15867376c85b1371f6571208ea7e82dbd770/sparse_strips/vello_hybrid/src/scene.rs#L270-L294

## Next Steps

This PR only supports outlined glyphs. We need to support Emoji through bitmap and colr variants. I'd prefer to do that in separate PRs and keep this PR focused on the API and overall strategy.

## Notes

I haven't implemented caching of glyphs nor hinting instances. As per discussions, we wanted to keep the text API free from caching for now.