### PR TITLE
Apply uniform scaling to glyphs by scaling font size and glyph positions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae9a562c7b46107d9c78cd78b75bbe1e991c16734c0aee8ff0ee711fb8b620a"
+checksum = "13d5bbc2aa266907ed8ee977c9c9e16363cc2b001266104e13397b57f1d15f71"
 dependencies = [
  "skrifa",
  "yazi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,7 @@ dependencies = [
 name = "vello_common"
 version = "0.4.0"
 dependencies = [
+ "bytemuck",
  "roxmltree",
  "skrifa",
  "vello_api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2 0.5.2",
+ "objc2",
 ]
 
 [[package]]
@@ -857,16 +857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fontconfig-cache-parser"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f8afb20c8069fd676d27b214559a337cc619a605d25a87baa90b49a06f3b18"
-dependencies = [
- "bytemuck",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "fontconfig-parser"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,19 +886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b5fcb214137f01bc842c4fd633236255c51f8a24c6d3923eb8361c6d0940737"
 dependencies = [
  "bytemuck",
- "fontconfig-cache-parser",
  "hashbrown 0.15.2",
  "icu_locid",
  "memmap2",
- "objc2-core-foundation",
- "objc2-core-text",
- "objc2-foundation 0.3.0",
  "peniko",
  "read-fonts",
- "roxmltree",
  "smallvec",
- "windows",
- "windows-core",
 ]
 
 [[package]]
@@ -1736,15 +1719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,10 +1727,10 @@ dependencies = [
  "bitflags 2.8.0",
  "block2",
  "libc",
- "objc2 0.5.2",
+ "objc2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
  "objc2-quartz-core",
 ]
 
@@ -1768,9 +1742,9 @@ checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2 0.5.2",
+ "objc2",
  "objc2-core-location",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1780,8 +1754,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1792,17 +1766,8 @@ checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
-dependencies = [
- "bitflags 2.8.0",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1812,8 +1777,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-foundation",
  "objc2-metal",
 ]
 
@@ -1824,19 +1789,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2",
- "objc2 0.5.2",
+ "objc2",
  "objc2-contacts",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fde15abfe00bf9f1eda220addbdfa6c62b0e5595e98208e8cdbc2ec0f6970a6"
-dependencies = [
- "bitflags 2.8.0",
- "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1855,17 +1810,7 @@ dependencies = [
  "block2",
  "dispatch",
  "libc",
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
-dependencies = [
- "bitflags 2.8.0",
- "objc2 0.6.0",
+ "objc2",
 ]
 
 [[package]]
@@ -1875,9 +1820,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2",
- "objc2 0.5.2",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1888,8 +1833,8 @@ checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1900,8 +1845,8 @@ checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-foundation",
  "objc2-metal",
 ]
 
@@ -1911,8 +1856,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1923,12 +1868,12 @@ checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2 0.5.2",
+ "objc2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
  "objc2-link-presentation",
  "objc2-quartz-core",
  "objc2-symbols",
@@ -1943,8 +1888,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1955,9 +1900,9 @@ checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2 0.5.2",
+ "objc2",
  "objc2-core-location",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4034,9 +3979,9 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2 0.5.2",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.2.2",
+ "objc2-foundation",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ name = "vello_common"
 version = "0.4.0"
 dependencies = [
  "roxmltree",
+ "skrifa",
  "vello_api",
 ]
 
@@ -3047,6 +3048,7 @@ version = "0.4.0"
 dependencies = [
  "image",
  "oxipng",
+ "skrifa",
  "vello_common",
 ]
 
@@ -3069,6 +3071,7 @@ dependencies = [
  "png",
  "pollster",
  "roxmltree",
+ "skrifa",
  "vello_common",
  "wgpu",
  "winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +692,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +886,21 @@ dependencies = [
  "slotmap",
  "tinyvec",
  "ttf-parser",
+]
+
+[[package]]
+name = "fontique"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5fcb214137f01bc842c4fd633236255c51f8a24c6d3923eb8361c6d0940737"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.15.2",
+ "icu_locid",
+ "memmap2",
+ "peniko",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -1101,6 +1133,8 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1147,6 +1181,18 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+]
 
 [[package]]
 name = "id-arena"
@@ -1409,6 +1455,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litrs"
@@ -1753,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -1938,6 +1990,19 @@ dependencies = [
  "redox_syscall 0.5.8",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parley"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d1c2b33b240c246f06cfceac48dc6c96040cb177d2aa5348899982b298b5577"
+dependencies = [
+ "fontique",
+ "hashbrown 0.15.2",
+ "peniko",
+ "skrifa",
+ "swash",
 ]
 
 [[package]]
@@ -2527,9 +2592,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skrifa"
-version = "0.26.4"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6667e349abb2e6e850b31bc638a11f7fadd7e4cf113b71947c46bf6d5fe0dbc9"
+checksum = "8cc1aa86c26dbb1b63875a7180aa0819709b33348eb5b1491e4321fae388179d"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -2555,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2674,6 +2739,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "swash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5bbc2aa266907ed8ee977c9c9e16363cc2b001266104e13397b57f1d15f71"
+dependencies = [
+ "skrifa",
+ "yazi",
+ "zeno",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2862,15 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
 ]
 
 [[package]]
@@ -3069,6 +3154,7 @@ name = "vello_hybrid"
 version = "0.4.0"
 dependencies = [
  "bytemuck",
+ "parley",
  "png",
  "pollster",
  "roxmltree",
@@ -4020,6 +4106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,6 +4188,18 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "yazi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+
+[[package]]
+name = "zeno"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0de2315dc13d00e5df3cd6b8d2124a6eaec6a2d4b6a1c5f37b7efad17fcc17"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -866,6 +866,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fontconfig-cache-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f8afb20c8069fd676d27b214559a337cc619a605d25a87baa90b49a06f3b18"
+dependencies = [
+ "bytemuck",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,12 +905,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b5fcb214137f01bc842c4fd633236255c51f8a24c6d3923eb8361c6d0940737"
 dependencies = [
  "bytemuck",
+ "fontconfig-cache-parser",
  "hashbrown 0.15.2",
  "icu_locid",
  "memmap2",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.0",
  "peniko",
  "read-fonts",
+ "roxmltree",
  "smallvec",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -1728,6 +1745,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,10 +1762,10 @@ dependencies = [
  "bitflags 2.8.0",
  "block2",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-quartz-core",
 ]
 
@@ -1751,9 +1777,9 @@ checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1763,8 +1789,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1775,8 +1801,17 @@ checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -1786,8 +1821,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -1798,9 +1833,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fde15abfe00bf9f1eda220addbdfa6c62b0e5595e98208e8cdbc2ec0f6970a6"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1819,7 +1864,17 @@ dependencies = [
  "block2",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.0",
 ]
 
 [[package]]
@@ -1829,9 +1884,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1842,8 +1897,8 @@ checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1854,8 +1909,8 @@ checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -1865,8 +1920,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1877,12 +1932,12 @@ checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core",
  "objc2-symbols",
@@ -1897,8 +1952,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1909,9 +1964,9 @@ checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.8.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4028,9 +4083,9 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2",
+ "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",

--- a/sparse_strips/vello_api/src/glyph.rs
+++ b/sparse_strips/vello_api/src/glyph.rs
@@ -1,0 +1,18 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Types for glyphs.
+
+/// Positioned glyph.
+#[derive(Copy, Clone, Default, Debug)]
+pub struct Glyph {
+    /// The font-specific identifier for this glyph.
+    ///
+    /// This ID is specific to the font being used and corresponds to the
+    /// glyph index within that font. It is *not* a Unicode code point.
+    pub id: u32,
+    /// X-offset in run, relative to transform.
+    pub x: f32,
+    /// Y-offset in run, relative to transform.
+    pub y: f32,
+}

--- a/sparse_strips/vello_api/src/lib.rs
+++ b/sparse_strips/vello_api/src/lib.rs
@@ -12,4 +12,5 @@ pub use peniko;
 pub use peniko::color;
 pub use peniko::kurbo;
 pub mod execute;
+pub mod glyph;
 pub mod paint;

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 vello_api = { workspace = true, default-features = true }
 # for pico_svg
 roxmltree = "0.20.0"
+skrifa = { workspace = true }
 
 [features]
 simd = ["vello_api/simd"]

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 vello_api = { workspace = true, default-features = true }
 # for pico_svg
 roxmltree = "0.20.0"
+bytemuck = { workspace = true }
 skrifa = { workspace = true }
 
 [features]

--- a/sparse_strips/vello_common/Cargo.toml
+++ b/sparse_strips/vello_common/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 vello_api = { workspace = true, default-features = true }
 # for pico_svg
 roxmltree = "0.20.0"
-bytemuck = { workspace = true }
+bytemuck = { workspace = true, features = [] }
 skrifa = { workspace = true }
 
 [features]

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -4,7 +4,6 @@
 //! Processing and drawing glyphs.
 
 use crate::peniko::Font;
-use skrifa::OutlineGlyphCollection;
 use skrifa::instance::Size;
 use skrifa::outline::DrawSettings;
 use skrifa::{

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -27,8 +27,8 @@ pub enum PreparedGlyph<'a> {
 pub struct OutlineGlyph<'a> {
     /// The path of the glyph.
     pub path: &'a BezPath,
-    /// The local transform of the glyph.
-    pub local_transform: Affine,
+    /// The global transform of the glyph.
+    pub transform: Affine,
 }
 
 /// Trait for types that can render glyphs.
@@ -101,20 +101,23 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
         let font =
             skrifa::FontRef::from_index(self.run.font.data.as_ref(), self.run.font.index).unwrap();
         let outlines = font.outline_glyphs();
-        let size = Size::new(self.run.font_size);
-        let hinting_instance = if self.run.hint {
-            // Only transformations including uniform scaling and translation can be hinted.
-            // Rotated, skewed, and other transformations cannot be hinted.
-            let [a, b, c, d, _, _] = self.run.transform.as_coeffs();
-            if a == d && b == 0.0 && c == 0.0 {
-                // TODO: Cache hinting instance.
+        let (transform, size, scale, hinting_instance) = if self.run.hint {
+            let (transform, size, scale) =
+                if let Some((scale, transform)) = take_uniform_scale(self.run.transform) {
+                    (
+                        transform,
+                        Size::new(self.run.font_size * scale as f32),
+                        scale,
+                    )
+                } else {
+                    (self.run.transform, Size::new(self.run.font_size), 1.0)
+                };
+            let hinting_instance =
                 HintingInstance::new(&outlines, size, self.run.normalized_coords, HINTING_OPTIONS)
-                    .ok()
-            } else {
-                None
-            }
+                    .ok();
+            (transform, size, scale, hinting_instance)
         } else {
-            None
+            (self.run.transform, Size::new(self.run.font_size), 1.0, None)
         };
 
         let render_glyph = match style {
@@ -136,16 +139,17 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
             if outline.draw(draw_settings, &mut path).is_err() {
                 continue;
             }
-            let mut transform = Affine::translate(Vec2::new(glyph.x as f64, glyph.y as f64));
+            let mut local_transform =
+                Affine::translate(Vec2::new(glyph.x as f64 * scale, glyph.y as f64 * scale));
             if let Some(glyph_transform) = self.run.glyph_transform {
-                transform *= glyph_transform;
+                local_transform *= glyph_transform;
             }
 
             render_glyph(
                 self.renderer,
                 PreparedGlyph::Outline(OutlineGlyph {
                     path: &path.0,
-                    local_transform: transform,
+                    transform: transform * local_transform,
                 }),
             );
         }
@@ -172,6 +176,20 @@ struct GlyphRun<'a> {
     pub normalized_coords: &'a [skrifa::instance::NormalizedCoord],
     /// Controls whether font hinting is enabled.
     pub hint: bool,
+}
+
+/// If `transform` has a uniform scale without rotation or skew, return the scale factor and the
+/// transform with the scale factored out. Translation remains unchanged.
+fn take_uniform_scale(transform: Affine) -> Option<(f64, Affine)> {
+    let [a, b, c, d, e, f] = transform.as_coeffs();
+    if a == d && b == 0.0 && c == 0.0 {
+        let scale = a;
+        let transform_without_scale = Affine::new([1.0, 0.0, 0.0, 1.0, e, f]);
+
+        Some((scale, transform_without_scale))
+    } else {
+        None
+    }
 }
 
 // TODO: Although these are sane defaults, we might want to make them
@@ -232,4 +250,75 @@ mod tests {
 
     const _NORMALISED_COORD_SIZE_MATCHES: () =
         assert!(size_of::<skrifa::instance::NormalizedCoord>() == size_of::<NormalizedCoord>());
+
+    mod take_uniform_scale {
+        use super::*;
+
+        #[test]
+        fn identity_transform() {
+            let identity = Affine::IDENTITY;
+            let result = take_uniform_scale(identity);
+            assert!(result.is_some());
+            let (scale, transform) = result.unwrap();
+            assert!((scale - 1.0).abs() < 1e-10);
+            assert!(transform == Affine::IDENTITY);
+        }
+
+        #[test]
+        fn pure_uniform_scale() {
+            let scale_transform = Affine::scale(2.5);
+            let result = take_uniform_scale(scale_transform);
+            assert!(result.is_some());
+            let (scale, transform) = result.unwrap();
+            assert!((scale - 2.5).abs() < 1e-10);
+            assert!(transform == Affine::IDENTITY);
+        }
+
+        #[test]
+        fn scale_with_translation() {
+            let scale_translate = Affine::scale(3.0).then_translate(Vec2::new(10.0, 20.0));
+            let result = take_uniform_scale(scale_translate);
+            assert!(result.is_some());
+            let (scale, transform) = result.unwrap();
+            assert!((scale - 3.0).abs() < 1e-10);
+            // The translation should be adjusted by the scale factor
+            assert!(transform == Affine::translate(Vec2::new(10.0, 20.0)));
+        }
+
+        #[test]
+        fn pure_translation() {
+            let translation = Affine::translate(Vec2::new(5.0, 7.0));
+            let result = take_uniform_scale(translation);
+            assert!(result.is_some());
+            let (scale, transform) = result.unwrap();
+            assert!((scale - 1.0).abs() < 1e-10);
+            assert!(transform == translation);
+        }
+
+        #[test]
+        fn non_uniform_scale() {
+            let non_uniform = Affine::scale_non_uniform(2.0, 3.0);
+            assert!(take_uniform_scale(non_uniform).is_none());
+        }
+
+        #[test]
+        fn rotation_transform() {
+            let rotation = Affine::rotate(std::f64::consts::PI / 4.0);
+            assert!(take_uniform_scale(rotation).is_none());
+        }
+
+        #[test]
+        fn skew_transform() {
+            let skew = Affine::skew(0.5, 0.0);
+            assert!(take_uniform_scale(skew).is_none());
+        }
+
+        #[test]
+        fn complex_transform() {
+            let complex = Affine::translate(Vec2::new(10.0, 20.0))
+                .then_rotate(std::f64::consts::PI / 6.0)
+                .then_scale(2.0);
+            assert!(take_uniform_scale(complex).is_none());
+        }
+    }
 }

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -103,7 +103,8 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
         let outlines = font.outline_glyphs();
         let size = Size::new(self.run.font_size);
         let hinting_instance = if self.run.hint {
-            // Rotated, skewed, or other transformations cannot be hinted.
+            // Only transformations including uniform scaling and translation can be hinted.
+            // Rotated, skewed, and other transformations cannot be hinted.
             let [a, b, c, d, _, _] = self.run.transform.as_coeffs();
             if a == d && b == 0.0 && c == 0.0 {
                 // TODO: Cache hinting instance.

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -121,10 +121,9 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
             Style::Fill => GlyphRenderer::fill_glyph,
             Style::Stroke => GlyphRenderer::stroke_glyph,
         };
-        // Re-use the same `path` allocation for each glyph.
+        // Reuse the same `path` allocation for each glyph.
         let mut path = OutlinePath(BezPath::new());
         for glyph in glyphs {
-            path.0.truncate(0);
             let draw_settings = if let Some(hinting_instance) = &hinting_instance {
                 DrawSettings::hinted(hinting_instance, false)
             } else {
@@ -133,6 +132,7 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
             let Some(outline) = outlines.get(GlyphId::new(glyph.id)) else {
                 continue;
             };
+            path.0.truncate(0);
             if outline.draw(draw_settings, &mut path).is_err() {
                 continue;
             }

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -88,16 +88,16 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
     }
 
     /// Consumes the builder and fills the glyphs with the current configuration.
-    pub fn fill_glyphs(self, glyphs: impl Iterator<Item = &'a Glyph>) {
+    pub fn fill_glyphs(self, glyphs: impl Iterator<Item = Glyph>) {
         self.render(glyphs, Style::Fill);
     }
 
     /// Consumes the builder and strokes the glyphs with the current configuration.
-    pub fn stroke_glyphs(self, glyphs: impl Iterator<Item = &'a Glyph>) {
+    pub fn stroke_glyphs(self, glyphs: impl Iterator<Item = Glyph>) {
         self.render(glyphs, Style::Stroke);
     }
 
-    fn render(self, glyphs: impl Iterator<Item = &'a Glyph>, style: Style) {
+    fn render(self, glyphs: impl Iterator<Item = Glyph>, style: Style) {
         let font =
             skrifa::FontRef::from_index(self.run.font.data.as_ref(), self.run.font.index).unwrap();
         let outlines = font.outline_glyphs();

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -103,10 +103,11 @@ impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
         let outlines = font.outline_glyphs();
         let size = Size::new(self.run.font_size);
         let hinting_instance = if self.run.hint {
-            // Only transformations including uniform scaling and translation can be hinted.
-            // Rotated, skewed, and other transformations cannot be hinted.
+            // Only apply hinting if the transform is a simple translation.
+            // Scaled, rotated, skewed, and other transformations cannot be hinted.
             let [a, b, c, d, _, _] = self.run.transform.as_coeffs();
-            if a == d && b == 0.0 && c == 0.0 {
+            // TODO: Consider scaling the font size if the transform is a uniform scale.
+            if a == 1.0 && d == 1.0 && b == 0.0 && c == 0.0 {
                 // TODO: Cache hinting instance.
                 HintingInstance::new(&outlines, size, self.run.normalized_coords, HINTING_OPTIONS)
                     .ok()

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -1,0 +1,190 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Processing and drawing glyphs.
+
+use crate::peniko::Font;
+use skrifa::instance::{NormalizedCoord, Size};
+use skrifa::outline::DrawSettings;
+use skrifa::{
+    GlyphId, MetadataProvider,
+    outline::{HintingInstance, HintingOptions, OutlinePen},
+};
+use vello_api::kurbo::{Affine, BezPath, Vec2};
+
+pub use vello_api::glyph::*;
+
+/// A glyph prepared for rendering.
+#[derive(Debug)]
+pub enum PreparedGlyph {
+    /// A glyph defined by its outline.
+    Outline(OutlineGlyph),
+    // TODO: Image and Colr variants.
+}
+
+/// A glyph defined by a path (its outline) and a local transform.
+#[derive(Debug)]
+pub struct OutlineGlyph {
+    /// The path of the glyph.
+    pub path: BezPath,
+    /// The local transform of the glyph.
+    pub local_transform: Affine,
+}
+
+/// Trait for types that can render glyphs.
+pub trait GlyphRenderer {
+    /// Fill glyphs with the current paint and fill rule.
+    fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>);
+
+    /// Stroke glyphs with the current paint and stroke settings.
+    fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>);
+}
+
+/// A builder for configuring and drawing glyphs.
+#[derive(Debug)]
+pub struct GlyphRunBuilder<'a, T: GlyphRenderer + 'a> {
+    run: GlyphRun,
+    renderer: &'a mut T,
+}
+
+impl<'a, T: GlyphRenderer + 'a> GlyphRunBuilder<'a, T> {
+    /// Creates a new builder for drawing glyphs.
+    pub fn new(font: Font, renderer: &'a mut T) -> Self {
+        Self {
+            run: GlyphRun {
+                font,
+                font_size: 16.0,
+                glyph_transform: None,
+                hint: true,
+                normalized_coords: Vec::new(),
+            },
+            renderer,
+        }
+    }
+
+    /// Set the font size in pixels per em.
+    pub fn font_size(mut self, size: f32) -> Self {
+        self.run.font_size = size;
+        self
+    }
+
+    /// Set the per-glyph transform. Can be used to apply skew to simulate italic text.
+    pub fn glyph_transform(mut self, transform: Affine) -> Self {
+        self.run.glyph_transform = Some(transform);
+        self
+    }
+
+    /// Set whether font hinting is enabled.
+    pub fn hint(mut self, hint: bool) -> Self {
+        self.run.hint = hint;
+        self
+    }
+
+    /// Set normalized variation coordinates for variable fonts.
+    pub fn normalized_coords(mut self, coords: Vec<NormalizedCoord>) -> Self {
+        self.run.normalized_coords = coords;
+        self
+    }
+
+    /// Consumes the builder and fills the glyphs with the current configuration.
+    pub fn fill_glyphs(self, glyphs: impl Iterator<Item = &'a Glyph>) {
+        self.renderer
+            .fill_glyphs(Self::prepare_glyphs(&self.run, glyphs));
+    }
+
+    /// Consumes the builder and strokes the glyphs with the current configuration.
+    pub fn stroke_glyphs(self, glyphs: impl Iterator<Item = &'a Glyph>) {
+        self.renderer
+            .stroke_glyphs(Self::prepare_glyphs(&self.run, glyphs));
+    }
+
+    fn prepare_glyphs(
+        run: &GlyphRun,
+        glyphs: impl Iterator<Item = &'a Glyph>,
+    ) -> impl Iterator<Item = PreparedGlyph> {
+        let font = skrifa::FontRef::from_index(run.font.data.as_ref(), run.font.index).unwrap();
+        let outlines = font.outline_glyphs();
+        let size = Size::new(run.font_size);
+        let normalized_coords = run.normalized_coords.as_slice();
+        let hinting_instance = if run.hint {
+            // TODO: Cache hinting instance.
+            HintingInstance::new(&outlines, size, normalized_coords, HINTING_OPTIONS).ok()
+        } else {
+            None
+        };
+        glyphs.filter_map(move |glyph| {
+            let draw_settings = if let Some(hinting_instance) = &hinting_instance {
+                DrawSettings::hinted(hinting_instance, false)
+            } else {
+                DrawSettings::unhinted(size, normalized_coords)
+            };
+            let outline = outlines.get(GlyphId::new(glyph.id))?;
+            let mut path = OutlinePath(BezPath::new());
+            outline.draw(draw_settings, &mut path).ok()?;
+            let mut transform = Affine::translate(Vec2::new(glyph.x as f64, glyph.y as f64));
+            if let Some(glyph_transform) = run.glyph_transform {
+                transform *= glyph_transform;
+            }
+            Some(PreparedGlyph::Outline(OutlineGlyph {
+                path: path.0,
+                local_transform: transform,
+            }))
+        })
+    }
+}
+
+/// A sequence of glyphs with shared rendering properties.
+#[derive(Clone, Debug)]
+struct GlyphRun {
+    /// Font for all glyphs in the run.
+    pub font: Font,
+    /// Size of the font in pixels per em.
+    pub font_size: f32,
+    /// Per-glyph transform. Can be used to apply skew to simulate italic text.
+    pub glyph_transform: Option<Affine>,
+    /// Normalized variation coordinates for variable fonts.
+    pub normalized_coords: Vec<NormalizedCoord>,
+    /// Controls whether font hinting is enabled.
+    pub hint: bool,
+}
+
+// TODO: Although these are sane defaults, we might want to make them
+// configurable.
+const HINTING_OPTIONS: HintingOptions = HintingOptions {
+    engine: skrifa::outline::Engine::AutoFallback,
+    target: skrifa::outline::Target::Smooth {
+        mode: skrifa::outline::SmoothMode::Lcd,
+        symmetric_rendering: false,
+        preserve_linear_metrics: true,
+    },
+};
+
+struct OutlinePath(BezPath);
+
+// Note that we flip the y-axis to match our coordinate system.
+impl OutlinePen for OutlinePath {
+    #[inline]
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.0.move_to((x, -y));
+    }
+
+    #[inline]
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.0.line_to((x, -y));
+    }
+
+    #[inline]
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        self.0.curve_to((cx0, -cy0), (cx1, -cy1), (x, -y));
+    }
+
+    #[inline]
+    fn quad_to(&mut self, cx: f32, cy: f32, x: f32, y: f32) {
+        self.0.quad_to((cx, -cy), (x, -y));
+    }
+
+    #[inline]
+    fn close(&mut self) {
+        self.0.close_path();
+    }
+}

--- a/sparse_strips/vello_common/src/glyph.rs
+++ b/sparse_strips/vello_common/src/glyph.rs
@@ -161,17 +161,17 @@ enum Style {
 #[derive(Clone, Debug)]
 struct GlyphRun<'a> {
     /// Font for all glyphs in the run.
-    pub font: Font,
+    font: Font,
     /// Size of the font in pixels per em.
-    pub font_size: f32,
+    font_size: f32,
     /// Global transform.
-    pub transform: Affine,
+    transform: Affine,
     /// Per-glyph transform. Can be used to apply skew to simulate italic text.
-    pub glyph_transform: Option<Affine>,
+    glyph_transform: Option<Affine>,
     /// Normalized variation coordinates for variable fonts.
-    pub normalized_coords: &'a [skrifa::instance::NormalizedCoord],
+    normalized_coords: &'a [skrifa::instance::NormalizedCoord],
     /// Controls whether font hinting is enabled.
-    pub hint: bool,
+    hint: bool,
 }
 
 // TODO: Although these are sane defaults, we might want to make them

--- a/sparse_strips/vello_common/src/lib.rs
+++ b/sparse_strips/vello_common/src/lib.rs
@@ -14,6 +14,7 @@ only break in edge cases, and some of them are also only related to conversions 
 
 pub mod coarse;
 pub mod flatten;
+pub mod glyph;
 pub mod pico_svg;
 pub mod pixmap;
 pub mod strip;

--- a/sparse_strips/vello_cpu/Cargo.toml
+++ b/sparse_strips/vello_cpu/Cargo.toml
@@ -17,6 +17,7 @@ vello_common = { workspace = true }
 [dev-dependencies]
 oxipng = { workspace = true, features = ["freestanding", "parallel"] }
 image = { workspace = true, features = ["png"] }
+skrifa = { workspace = true }
 
 [lints]
 workspace = true

--- a/sparse_strips/vello_cpu/snapshots/filled_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/filled_glyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a876a4537bdc5812158aff76475b4e50ca70a8423c3e418bd8a640ca43b218e
+size 2391

--- a/sparse_strips/vello_cpu/snapshots/scaled_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/scaled_glyphs.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18af7f08792862fb350eea77439d96be2bb3118b7ef0711d2d0ca859e38de06f
-size 2405
+oid sha256:5305569218595bbe61303802b495c4a2104b96daf228d9fd3cb2ac6c9d9a5fe5
+size 2434

--- a/sparse_strips/vello_cpu/snapshots/scaled_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/scaled_glyphs.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81197e38ec9d32f7fd6a1124fa3cb28d0e2f6ed03f70eb4f163e1864db31dd5f
-size 2527
+oid sha256:5305569218595bbe61303802b495c4a2104b96daf228d9fd3cb2ac6c9d9a5fe5
+size 2434

--- a/sparse_strips/vello_cpu/snapshots/scaled_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/scaled_glyphs.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18af7f08792862fb350eea77439d96be2bb3118b7ef0711d2d0ca859e38de06f
-size 2405
+oid sha256:81197e38ec9d32f7fd6a1124fa3cb28d0e2f6ed03f70eb4f163e1864db31dd5f
+size 2527

--- a/sparse_strips/vello_cpu/snapshots/scaled_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/scaled_glyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18af7f08792862fb350eea77439d96be2bb3118b7ef0711d2d0ca859e38de06f
+size 2405

--- a/sparse_strips/vello_cpu/snapshots/skewed_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/skewed_glyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ba918c5de97f7b2dbdb7e282cd2f57b26fd0d8b43e576c388a738b01462df79
+size 3161

--- a/sparse_strips/vello_cpu/snapshots/stroked_glyphs.png
+++ b/sparse_strips/vello_cpu/snapshots/stroked_glyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbed811f8c94c1cea5b7dbe17fb69b83b66f47cef0a59ba678b55225f13dfe24
+size 3343

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -186,8 +186,7 @@ impl GlyphRenderer for RenderContext {
     fn fill_glyph(&mut self, glyph: PreparedGlyph<'_>) {
         match glyph {
             PreparedGlyph::Outline(glyph) => {
-                let transform = self.transform * glyph.local_transform;
-                flatten::fill(glyph.path, transform, &mut self.line_buf);
+                flatten::fill(glyph.path, glyph.transform, &mut self.line_buf);
                 self.render_path(Fill::NonZero, self.paint.clone());
             }
         }
@@ -196,8 +195,12 @@ impl GlyphRenderer for RenderContext {
     fn stroke_glyph(&mut self, glyph: PreparedGlyph<'_>) {
         match glyph {
             PreparedGlyph::Outline(glyph) => {
-                let transform = self.transform * glyph.local_transform;
-                flatten::stroke(glyph.path, &self.stroke, transform, &mut self.line_buf);
+                flatten::stroke(
+                    glyph.path,
+                    &self.stroke,
+                    glyph.transform,
+                    &mut self.line_buf,
+                );
                 self.render_path(Fill::NonZero, self.paint.clone());
             }
         }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -183,26 +183,22 @@ impl RenderContext {
 }
 
 impl GlyphRenderer for RenderContext {
-    fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
-        for glyph in glyphs {
-            match glyph {
-                PreparedGlyph::Outline(glyph) => {
-                    let transform = self.transform * glyph.local_transform;
-                    flatten::fill(&glyph.path, transform, &mut self.line_buf);
-                    self.render_path(Fill::NonZero, self.paint.clone());
-                }
+    fn fill_glyph(&mut self, glyph: PreparedGlyph<'_>) {
+        match glyph {
+            PreparedGlyph::Outline(glyph) => {
+                let transform = self.transform * glyph.local_transform;
+                flatten::fill(&glyph.path, transform, &mut self.line_buf);
+                self.render_path(Fill::NonZero, self.paint.clone());
             }
         }
     }
 
-    fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
-        for glyph in glyphs {
-            match glyph {
-                PreparedGlyph::Outline(glyph) => {
-                    let transform = self.transform * glyph.local_transform;
-                    flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
-                    self.render_path(Fill::NonZero, self.paint.clone());
-                }
+    fn stroke_glyph(&mut self, glyph: PreparedGlyph<'_>) {
+        match glyph {
+            PreparedGlyph::Outline(glyph) => {
+                let transform = self.transform * glyph.local_transform;
+                flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
+                self.render_path(Fill::NonZero, self.paint.clone());
             }
         }
     }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -189,7 +189,7 @@ impl GlyphRenderer for RenderContext {
                 PreparedGlyph::Outline(glyph) => {
                     let transform = self.transform * glyph.local_transform;
                     flatten::fill(&glyph.path, transform, &mut self.line_buf);
-                    self.render_path(self.fill_rule, self.paint.clone());
+                    self.render_path(Fill::NonZero, self.paint.clone());
                 }
             }
         }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -187,7 +187,7 @@ impl GlyphRenderer for RenderContext {
         match glyph {
             PreparedGlyph::Outline(glyph) => {
                 let transform = self.transform * glyph.local_transform;
-                flatten::fill(&glyph.path, transform, &mut self.line_buf);
+                flatten::fill(glyph.path, transform, &mut self.line_buf);
                 self.render_path(Fill::NonZero, self.paint.clone());
             }
         }
@@ -197,7 +197,7 @@ impl GlyphRenderer for RenderContext {
         match glyph {
             PreparedGlyph::Outline(glyph) => {
                 let transform = self.transform * glyph.local_transform;
-                flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
+                flatten::stroke(glyph.path, &self.stroke, transform, &mut self.line_buf);
                 self.render_path(Fill::NonZero, self.paint.clone());
             }
         }

--- a/sparse_strips/vello_cpu/src/render.rs
+++ b/sparse_strips/vello_cpu/src/render.rs
@@ -97,7 +97,7 @@ impl RenderContext {
 
     /// Creates a builder for drawing a run of glyphs that have the same attributes.
     pub fn glyph_run(&mut self, font: &Font) -> GlyphRunBuilder<'_, Self> {
-        GlyphRunBuilder::new(font.clone(), self)
+        GlyphRunBuilder::new(font.clone(), self.transform, self)
     }
 
     /// Set the current blend mode.

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -536,7 +536,7 @@ fn filled_glyphs() {
     ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
     ctx.glyph_run(&font)
         .font_size(font_size)
-        .fill_glyphs(glyphs.iter());
+        .fill_glyphs(glyphs.into_iter());
 
     check_ref(&ctx, "filled_glyphs");
 }
@@ -551,7 +551,7 @@ fn stroked_glyphs() {
     ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
     ctx.glyph_run(&font)
         .font_size(font_size)
-        .stroke_glyphs(glyphs.iter());
+        .stroke_glyphs(glyphs.into_iter());
 
     check_ref(&ctx, "stroked_glyphs");
 }
@@ -567,7 +567,7 @@ fn skewed_glyphs() {
     ctx.glyph_run(&font)
         .font_size(font_size)
         .glyph_transform(Affine::skew(-20_f64.to_radians().tan(), 0.0))
-        .fill_glyphs(glyphs.iter());
+        .fill_glyphs(glyphs.into_iter());
 
     check_ref(&ctx, "skewed_glyphs");
 }
@@ -582,7 +582,7 @@ fn scaled_glyphs() {
     ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
     ctx.glyph_run(&font)
         .font_size(font_size)
-        .fill_glyphs(glyphs.iter());
+        .fill_glyphs(glyphs.into_iter());
 
     check_ref(&ctx, "scaled_glyphs");
 }

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -572,6 +572,14 @@ fn skewed_glyphs() {
     check_ref(&ctx, "skewed_glyphs");
 }
 
+/// ***DO NOT USE THIS OUTSIDE OF THESE TESTS***
+///
+/// This function is used for _TESTING PURPOSES ONLY_. If you need to layout and shape
+/// text for your application, use a proper text shaping library like `Parley`.
+///
+/// We use this function as a convenience for testing; to get some glyphs shaped and laid
+/// out in a small amount of code without having to go through the trouble of setting up a
+/// full text layout pipeline, which you absolutely should do in application code.
 fn layout_glyphs(text: &str, font_size: f32) -> (Font, Vec<Glyph>) {
     const ROBOTO_FONT: &[u8] = include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
     let font = Font::new(Blob::new(Arc::new(ROBOTO_FONT)), 0);

--- a/sparse_strips/vello_cpu/tests/basic.rs
+++ b/sparse_strips/vello_cpu/tests/basic.rs
@@ -572,6 +572,21 @@ fn skewed_glyphs() {
     check_ref(&ctx, "skewed_glyphs");
 }
 
+#[test]
+fn scaled_glyphs() {
+    let mut ctx = get_ctx(150, 125, false);
+    let font_size: f32 = 25_f32;
+    let (font, glyphs) = layout_glyphs("Hello,\nworld!", font_size);
+
+    ctx.set_transform(Affine::translate((0., f64::from(font_size))).then_scale(2.0));
+    ctx.set_paint(REBECCA_PURPLE.with_alpha(0.5).into());
+    ctx.glyph_run(&font)
+        .font_size(font_size)
+        .fill_glyphs(glyphs.iter());
+
+    check_ref(&ctx, "scaled_glyphs");
+}
+
 /// ***DO NOT USE THIS OUTSIDE OF THESE TESTS***
 ///
 /// This function is used for _TESTING PURPOSES ONLY_. If you need to layout and shape

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -22,6 +22,7 @@ wgpu = { workspace = true }
 [dev-dependencies]
 winit = "0.30.9"
 skrifa = { workspace = true }
+parley = { version = "0.3.0", default-features = false, features = ["std"] }
 pollster = { workspace = true }
 png = "0.17.14"
 roxmltree = "0.20.0"

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -21,6 +21,7 @@ wgpu = { workspace = true }
 
 [dev-dependencies]
 winit = "0.30.9"
+skrifa = { workspace = true }
 pollster = { workspace = true }
 png = "0.17.14"
 roxmltree = "0.20.0"

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -22,7 +22,7 @@ wgpu = { workspace = true }
 [dev-dependencies]
 winit = "0.30.9"
 skrifa = { workspace = true }
-parley = { version = "0.3.0", default-features = false, features = ["std"] }
+parley = { version = "0.3.0", default-features = true }
 pollster = { workspace = true }
 png = "0.17.14"
 roxmltree = "0.20.0"

--- a/sparse_strips/vello_hybrid/Cargo.toml
+++ b/sparse_strips/vello_hybrid/Cargo.toml
@@ -22,7 +22,7 @@ wgpu = { workspace = true }
 [dev-dependencies]
 winit = "0.30.9"
 skrifa = { workspace = true }
-parley = { version = "0.3.0", default-features = true }
+parley = { version = "0.3.0", default-features = false, features = ["std"] }
 pollster = { workspace = true }
 png = "0.17.14"
 roxmltree = "0.20.0"

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -1,0 +1,249 @@
+// Copyright 2025 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Draws some text on screen.
+
+mod common;
+
+use common::{RenderContext, RenderSurface, create_vello_renderer, create_winit_window};
+use skrifa::MetadataProvider;
+use skrifa::raw::FileRef;
+use std::sync::Arc;
+use vello_common::glyph::Glyph;
+use vello_common::kurbo::Affine;
+use vello_common::peniko::color::palette;
+use vello_common::peniko::{Blob, Font};
+use vello_hybrid::{RenderParams, Renderer, Scene};
+use wgpu::RenderPassDescriptor;
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::{ActiveEventLoop, EventLoop},
+    window::{Window, WindowId},
+};
+
+const ROBOTO_FONT: &[u8] = include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
+
+fn main() {
+    let mut app = App {
+        context: RenderContext::new(),
+        renderers: vec![],
+        state: RenderState::Suspended(None),
+        scene: Scene::new(900, 600),
+    };
+
+    let event_loop = EventLoop::new().unwrap();
+    event_loop
+        .run_app(&mut app)
+        .expect("Couldn't run event loop");
+}
+
+#[derive(Debug)]
+enum RenderState<'s> {
+    Active {
+        surface: Box<RenderSurface<'s>>,
+        window: Arc<Window>,
+    },
+    Suspended(Option<Arc<Window>>),
+}
+
+struct App<'s> {
+    context: RenderContext,
+    renderers: Vec<Option<Renderer>>,
+    state: RenderState<'s>,
+    scene: Scene,
+}
+
+impl ApplicationHandler for App<'_> {
+    fn suspended(&mut self, _event_loop: &ActiveEventLoop) {
+        if let RenderState::Active { window, .. } = &self.state {
+            self.state = RenderState::Suspended(Some(window.clone()));
+        }
+    }
+
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let RenderState::Suspended(cached_window) = &mut self.state else {
+            return;
+        };
+
+        let window = cached_window.take().unwrap_or_else(|| {
+            create_winit_window(
+                event_loop,
+                self.scene.width().into(),
+                self.scene.height().into(),
+                true,
+            )
+        });
+
+        let size = window.inner_size();
+        let surface = pollster::block_on(self.context.create_surface(
+            window.clone(),
+            size.width,
+            size.height,
+            wgpu::PresentMode::AutoVsync,
+            wgpu::TextureFormat::Bgra8Unorm,
+        ));
+
+        self.renderers
+            .resize_with(self.context.devices.len(), || None);
+        self.renderers[surface.dev_id]
+            .get_or_insert_with(|| create_vello_renderer(&self.context, &surface));
+
+        self.state = RenderState::Active {
+            surface: Box::new(surface),
+            window,
+        };
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let surface = match &mut self.state {
+            RenderState::Active { surface, window } if window.id() == window_id => surface,
+            _ => return,
+        };
+
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(size) => {
+                self.context
+                    .resize_surface(surface, size.width, size.height);
+            }
+            WindowEvent::RedrawRequested => {
+                self.scene.reset();
+
+                draw_text(&mut self.scene);
+                let device_handle = &self.context.devices[surface.dev_id];
+                let render_params = RenderParams {
+                    width: surface.config.width,
+                    height: surface.config.height,
+                };
+                self.renderers[surface.dev_id].as_mut().unwrap().prepare(
+                    &device_handle.device,
+                    &device_handle.queue,
+                    &self.scene,
+                    &render_params,
+                );
+
+                let surface_texture = surface
+                    .surface
+                    .get_current_texture()
+                    .expect("failed to get surface texture");
+
+                let texture_view = surface_texture
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+
+                let mut encoder =
+                    device_handle
+                        .device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                            label: Some("Vello Render to Surface pass"),
+                        });
+                {
+                    let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                        label: Some("Render to Texture Pass"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &texture_view,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        occlusion_query_set: None,
+                        timestamp_writes: None,
+                    });
+                    self.renderers[surface.dev_id].as_mut().unwrap().render(
+                        &self.scene,
+                        &mut pass,
+                        &render_params,
+                    );
+                }
+
+                device_handle.queue.submit([encoder.finish()]);
+                surface_texture.present();
+
+                device_handle.device.poll(wgpu::Maintain::Poll);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn draw_text(ctx: &mut Scene) {
+    let font = Font::new(Blob::new(Arc::new(ROBOTO_FONT)), 0);
+    let font_ref = {
+        let file_ref = FileRef::new(font.data.as_ref()).unwrap();
+        match file_ref {
+            FileRef::Font(f) => f,
+            FileRef::Collection(collection) => collection.get(font.index).unwrap(),
+        }
+    };
+    let axes = font_ref.axes();
+    let size = 52_f32;
+    let font_size = skrifa::instance::Size::new(size);
+    let variations: Vec<(&str, f32)> = vec![];
+    let var_loc = axes.location(variations.as_slice());
+    let charmap = font_ref.charmap();
+    let metrics = font_ref.metrics(font_size, &var_loc);
+    let line_height = metrics.ascent - metrics.descent + metrics.leading;
+    let glyph_metrics = font_ref.glyph_metrics(font_size, &var_loc);
+
+    let mut pen_x = 0_f32;
+    let mut pen_y = 0_f32;
+
+    let text = "Hello, world!";
+
+    let glyphs = text
+        .chars()
+        .filter_map(|ch| {
+            if ch == '\n' {
+                pen_y += line_height;
+                pen_x = 0.0;
+                return None;
+            }
+            let gid = charmap.map(ch).unwrap_or_default();
+            let advance = glyph_metrics.advance_width(gid).unwrap_or_default();
+            let x = pen_x;
+            pen_x += advance;
+            Some(Glyph {
+                id: gid.to_u32(),
+                x,
+                y: pen_y,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    ctx.set_paint(palette::css::WHITE.into());
+    let transform = Affine::scale(2.0).then_translate((0., f64::from(size) * 2.0).into());
+    ctx.set_transform(transform);
+
+    // Fill the text
+    ctx.glyph_run(&font)
+        .normalized_coords(vec![])
+        .font_size(size)
+        .hint(true)
+        .fill_glyphs(glyphs.iter());
+
+    ctx.set_transform(transform.then_translate((0., f64::from(size) * 2.0).into()));
+
+    // Stroke the text
+    ctx.glyph_run(&font)
+        .font_size(size)
+        .hint(true)
+        .stroke_glyphs(glyphs.iter());
+
+    ctx.set_transform(transform.then_translate((0., f64::from(size) * 4.0).into()));
+
+    // Skew the text to the right
+    ctx.glyph_run(&font)
+        .font_size(size)
+        .glyph_transform(Affine::skew(-20_f64.to_radians().tan(), 0.0))
+        .hint(true)
+        .stroke_glyphs(glyphs.iter());
+}

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -214,7 +214,7 @@ fn draw_text(
     builder.push_default(StyleProperty::LineHeight(1.3));
     builder.push_default(StyleProperty::FontSize(32.0));
 
-    let mut layout: Layout<ColorBrush> = builder.build(&text);
+    let mut layout: Layout<ColorBrush> = builder.build(text);
     let max_advance = Some(400.0);
     layout.break_all_lines(max_advance);
     layout.align(max_advance, Alignment::Middle, AlignmentOptions::default());

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -225,7 +225,6 @@ fn draw_text(ctx: &mut Scene) {
 
     // Fill the text
     ctx.glyph_run(&font)
-        .normalized_coords(vec![])
         .font_size(size)
         .hint(true)
         .fill_glyphs(glyphs.iter());

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -24,8 +24,6 @@ use winit::{
     window::{Window, WindowId},
 };
 
-const ROBOTO_FONT: &[u8] = include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
-
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct ColorBrush {
     color: AlphaColor<Srgb>,
@@ -46,8 +44,6 @@ fn main() {
         state: RenderState::Suspended(None),
         scene: Scene::new(900, 600),
     };
-
-    app.font_cx.collection.register_fonts(ROBOTO_FONT.to_vec());
 
     let event_loop = EventLoop::new().unwrap();
     event_loop

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -24,6 +24,8 @@ use winit::{
     window::{Window, WindowId},
 };
 
+const ROBOTO_FONT: &[u8] = include_bytes!("../../../examples/assets/roboto/Roboto-Regular.ttf");
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct ColorBrush {
     color: AlphaColor<Srgb>,
@@ -44,6 +46,11 @@ fn main() {
         state: RenderState::Suspended(None),
         scene: Scene::new(900, 600),
     };
+
+    // Note: If you set `default-features = true` in the `parley` dependency, you automatically
+    // get access to system fonts. Since we want to ensure this example can be compiled to Wasm,
+    // we are passing the font data directly to the font context.
+    app.font_cx.collection.register_fonts(ROBOTO_FONT.to_vec());
 
     let event_loop = EventLoop::new().unwrap();
     event_loop

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -219,11 +219,8 @@ fn draw_text(
 
     for line in layout.lines() {
         for item in line.items() {
-            match item {
-                PositionedLayoutItem::GlyphRun(glyph_run) => {
-                    render_glyph_run(ctx, &glyph_run, 30);
-                }
-                _ => {}
+            if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
+                render_glyph_run(ctx, &glyph_run, 30);
             }
         }
     }

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -136,7 +136,7 @@ impl ApplicationHandler for App<'_> {
 
                 draw_text(
                     &mut self.scene,
-                    String::from("Hello from Vello Hybrid and Parley!"),
+                    "Hello from Vello Hybrid and Parley!",
                     &mut self.font_cx,
                     &mut self.layout_cx,
                 );

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -11,7 +11,6 @@ use parley::{
     Alignment, AlignmentOptions, FontContext, GlyphRun, Layout, LayoutContext,
     PositionedLayoutItem, StyleProperty,
 };
-use skrifa::instance::NormalizedCoord;
 use std::sync::Arc;
 use vello_common::color::palette::css::WHITE;
 use vello_common::color::{AlphaColor, Srgb};
@@ -244,17 +243,13 @@ fn render_glyph_run(ctx: &mut Scene, glyph_run: &GlyphRun<'_, ColorBrush>, paddi
     let run = glyph_run.run();
     let font = run.font();
     let font_size = run.font_size();
-    let normalized_coords = run
-        .normalized_coords()
-        .iter()
-        .map(|coord| NormalizedCoord::from_bits(*coord))
-        .collect::<Vec<_>>();
+    let normalized_coords = bytemuck::cast_slice(run.normalized_coords());
 
     let style = glyph_run.style();
     ctx.set_paint(style.brush.color.into());
     ctx.glyph_run(font)
         .font_size(font_size)
-        .normalized_coords(bytemuck::cast_slice(normalized_coords.as_slice()))
+        .normalized_coords(normalized_coords)
         .hint(true)
         .fill_glyphs(glyphs);
 }

--- a/sparse_strips/vello_hybrid/examples/text.rs
+++ b/sparse_strips/vello_hybrid/examples/text.rs
@@ -203,11 +203,11 @@ impl ApplicationHandler for App<'_> {
 
 fn draw_text(
     ctx: &mut Scene,
-    text: String,
+    text: &str,
     font_cx: &mut FontContext,
     layout_cx: &mut LayoutContext<ColorBrush>,
 ) {
-    let mut builder = layout_cx.ranged_builder(font_cx, &text, 1.0);
+    let mut builder = layout_cx.ranged_builder(font_cx, text, 1.0);
     builder.push_default(FontFamily::parse("Roboto").unwrap());
     builder.push_default(StyleProperty::LineHeight(1.3));
     builder.push_default(StyleProperty::FontSize(32.0));

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -271,8 +271,7 @@ impl GlyphRenderer for Scene {
     fn fill_glyph(&mut self, glyph: PreparedGlyph<'_>) {
         match glyph {
             PreparedGlyph::Outline(glyph) => {
-                let transform = self.transform * glyph.local_transform;
-                flatten::fill(glyph.path, transform, &mut self.line_buf);
+                flatten::fill(glyph.path, glyph.transform, &mut self.line_buf);
                 self.render_path(Fill::NonZero, self.paint.clone());
             }
         }
@@ -281,8 +280,12 @@ impl GlyphRenderer for Scene {
     fn stroke_glyph(&mut self, glyph: PreparedGlyph<'_>) {
         match glyph {
             PreparedGlyph::Outline(glyph) => {
-                let transform = self.transform * glyph.local_transform;
-                flatten::stroke(glyph.path, &self.stroke, transform, &mut self.line_buf);
+                flatten::stroke(
+                    glyph.path,
+                    &self.stroke,
+                    glyph.transform,
+                    &mut self.line_buf,
+                );
                 self.render_path(Fill::NonZero, self.paint.clone());
             }
         }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -274,7 +274,7 @@ impl GlyphRenderer for Scene {
                 PreparedGlyph::Outline(glyph) => {
                     let transform = self.transform * glyph.local_transform;
                     flatten::fill(&glyph.path, transform, &mut self.line_buf);
-                    self.render_path(self.fill_rule, self.paint.clone());
+                    self.render_path(Fill::NonZero, self.paint.clone());
                 }
             }
         }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -7,8 +7,10 @@ use crate::render::{GpuStrip, RenderData};
 use vello_common::coarse::{Wide, WideTile};
 use vello_common::color::PremulRgba8;
 use vello_common::flatten::Line;
+use vello_common::glyph::{GlyphRenderer, GlyphRunBuilder, PreparedGlyph};
 use vello_common::kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke};
 use vello_common::paint::Paint;
+use vello_common::peniko::Font;
 use vello_common::peniko::color::palette::css::BLACK;
 use vello_common::peniko::{BlendMode, Compose, Fill, Mix};
 use vello_common::strip::Strip;
@@ -111,6 +113,11 @@ impl Scene {
     /// Stroke a rectangle with the current paint and stroke settings.
     pub fn stroke_rect(&mut self, rect: &Rect) {
         self.stroke_path(&rect.to_path(DEFAULT_TOLERANCE));
+    }
+
+    /// Creates a builder for drawing a run of glyphs that have the same attributes.
+    pub fn glyph_run(&mut self, font: &Font) -> GlyphRunBuilder<'_, Self> {
+        GlyphRunBuilder::new(font.clone(), self)
     }
 
     /// Set the blend mode for subsequent rendering operations.
@@ -256,6 +263,32 @@ impl Scene {
         RenderData {
             strips,
             alphas: self.alphas.clone(),
+        }
+    }
+}
+
+impl GlyphRenderer for Scene {
+    fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
+        for glyph in glyphs {
+            match glyph {
+                PreparedGlyph::Outline(glyph) => {
+                    let transform = self.transform * glyph.local_transform;
+                    flatten::fill(&glyph.path, transform, &mut self.line_buf);
+                    self.render_path(self.fill_rule, self.paint.clone());
+                }
+            }
+        }
+    }
+
+    fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
+        for glyph in glyphs {
+            match glyph {
+                PreparedGlyph::Outline(glyph) => {
+                    let transform = self.transform * glyph.local_transform;
+                    flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
+                    self.render_path(Fill::NonZero, self.paint.clone());
+                }
+            }
         }
     }
 }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -268,26 +268,22 @@ impl Scene {
 }
 
 impl GlyphRenderer for Scene {
-    fn fill_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
-        for glyph in glyphs {
-            match glyph {
-                PreparedGlyph::Outline(glyph) => {
-                    let transform = self.transform * glyph.local_transform;
-                    flatten::fill(&glyph.path, transform, &mut self.line_buf);
-                    self.render_path(Fill::NonZero, self.paint.clone());
-                }
+    fn fill_glyph(&mut self, glyph: PreparedGlyph<'_>) {
+        match glyph {
+            PreparedGlyph::Outline(glyph) => {
+                let transform = self.transform * glyph.local_transform;
+                flatten::fill(&glyph.path, transform, &mut self.line_buf);
+                self.render_path(Fill::NonZero, self.paint.clone());
             }
         }
     }
 
-    fn stroke_glyphs(&mut self, glyphs: impl Iterator<Item = PreparedGlyph>) {
-        for glyph in glyphs {
-            match glyph {
-                PreparedGlyph::Outline(glyph) => {
-                    let transform = self.transform * glyph.local_transform;
-                    flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
-                    self.render_path(Fill::NonZero, self.paint.clone());
-                }
+    fn stroke_glyph(&mut self, glyph: PreparedGlyph<'_>) {
+        match glyph {
+            PreparedGlyph::Outline(glyph) => {
+                let transform = self.transform * glyph.local_transform;
+                flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
+                self.render_path(Fill::NonZero, self.paint.clone());
             }
         }
     }

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -117,7 +117,7 @@ impl Scene {
 
     /// Creates a builder for drawing a run of glyphs that have the same attributes.
     pub fn glyph_run(&mut self, font: &Font) -> GlyphRunBuilder<'_, Self> {
-        GlyphRunBuilder::new(font.clone(), self)
+        GlyphRunBuilder::new(font.clone(), self.transform, self)
     }
 
     /// Set the blend mode for subsequent rendering operations.

--- a/sparse_strips/vello_hybrid/src/scene.rs
+++ b/sparse_strips/vello_hybrid/src/scene.rs
@@ -272,7 +272,7 @@ impl GlyphRenderer for Scene {
         match glyph {
             PreparedGlyph::Outline(glyph) => {
                 let transform = self.transform * glyph.local_transform;
-                flatten::fill(&glyph.path, transform, &mut self.line_buf);
+                flatten::fill(glyph.path, transform, &mut self.line_buf);
                 self.render_path(Fill::NonZero, self.paint.clone());
             }
         }
@@ -282,7 +282,7 @@ impl GlyphRenderer for Scene {
         match glyph {
             PreparedGlyph::Outline(glyph) => {
                 let transform = self.transform * glyph.local_transform;
-                flatten::stroke(&glyph.path, &self.stroke, transform, &mut self.line_buf);
+                flatten::stroke(glyph.path, &self.stroke, transform, &mut self.line_buf);
                 self.render_path(Fill::NonZero, self.paint.clone());
             }
         }


### PR DESCRIPTION
Builds on https://github.com/linebender/vello/pull/883 to use unscaled outlines for glyph rendering.